### PR TITLE
Fixed DetermineStartingTrack

### DIFF
--- a/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
@@ -409,13 +409,12 @@ namespace PersistentJobsMod.HarmonyPatches.JobGeneration {
             var tracks = new List<Track>();
             foreach (var tc in trainCars)
             {
-                if (!tc.derailed && tc.logicCar.BogiesOnSameTrack)
+                if (!tc.derailed)
                 {
                     var track = tc.logicCar.FrontBogieTrack;
-                    if (!tracks.Contains(track))
-                    {
-                        tracks.Add(track);
-                    }
+                    if (!tracks.Contains(track)) tracks.Add(track);
+                    track = tc.logicCar.RearBogieTrack;
+                    if (!tracks.Contains(track)) tracks.Add(track);
                 }
             }
             if (tracks.Count > 0)
@@ -429,7 +428,8 @@ namespace PersistentJobsMod.HarmonyPatches.JobGeneration {
                 Debug.Log($"[PersistentJobsMod] Could not determine a nice-looking starting track for train cars {string.Join(", ", trainCars.Select(tc => tc.ID))}");
                 return majorityTrack.FirstOrDefault();
             }
-            Debug.LogError($"Train cars {string.Join(", ", trainCars.Select(tc => tc.ID))} have no viable starting track");
+            //this should´t evem be reached, only case is if trainCars had just derailed cars (which wouldn´t be let in by by logic above)
+            Debug.LogError($"Train cars {string.Join(", ", trainCars.Select(tc => tc.ID))} are derailed and have no viable starting track");
             return null;
         }
 


### PR DESCRIPTION
Fixed DetermineStartingTrack to take track from non-derailed car in consist, resolves #30 . Also added logic to pick the most represented track, in case of consist overhanging.
Prebuilt .dll file [here](https://github.com/user-attachments/files/20019204/PersistentJobsMod.zip).
