### PR TITLE
Console commands and dotNet update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,4 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+/Directory.Build.props

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PersistentJobsMod</RootNamespace>
     <AssemblyName>PersistentJobsMod</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />


### PR DESCRIPTION
Changed PJ.ClearStationSpawnFlag to accept a wildcard for resetting all flags at once.
Added PJ.ExpireJobForConsistOfCar to expire a specific consists job.

Changed targeted dotNET framework to 4.8.1 which is LTS for dotNET 4
(Windows update upgraded it for me and is now preventing installation of 4.8...).