### PR TITLE
Fix exception in case StationController is null - not yet initialized

### DIFF
--- a/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
@@ -74,6 +74,10 @@ namespace PersistentJobsMod.HarmonyPatches.JobGeneration {
                 return;
             }
 
+            if (!StationController.allStations.Where(sc => sc != null && sc.gameObject != null).ToList().Any()) {
+                return;
+            }
+
             if (___unusedTrainCarsMarkedForDelete.Count == 0) {
                 return;
             }


### PR DESCRIPTION
Have ReassignRegularTrainCarsAndDeleteNonPlayerSpawnedCars() return early while StationController is null.
- (partially) fixes #36