### PR TITLE
Passenger Jobs compatibility

### DIFF
--- a/Info.json
+++ b/Info.json
@@ -8,5 +8,5 @@
 	"HomePage": "https://www.nexusmods.com/derailvalley/mods/794/",
 	"Repository": "https://raw.githubusercontent.com/Banjobeni/DerailValley-PersistentJobs/master/Repository.json",
 	"Requirements": ["MessageBox"],
-	"LoadAfter": ["MessageBox"]
+	"LoadAfter": ["MessageBox", "PassengerJobs"]
 }

--- a/Info.json
+++ b/Info.json
@@ -2,7 +2,7 @@
 	"Id": "PersistentJobsMod",
 	"DisplayName": "Persistent Jobs",
 	"Author": "Banjobeni",
-	"Version": "3.4.0",
+	"Version": "3.5.0",
 	"AssemblyName": "PersistentJobsMod.dll",
 	"EntryMethod": "PersistentJobsMod.Main.Load",
 	"HomePage": "https://www.nexusmods.com/derailvalley/mods/794/",

--- a/PersistentJobsMod/CarSpawningJobGenerators/CarSpawningJobGenerator.cs
+++ b/PersistentJobsMod/CarSpawningJobGenerators/CarSpawningJobGenerator.cs
@@ -18,10 +18,12 @@ namespace PersistentJobsMod.CarSpawningJobGenerators {
         }
 
         private static IEnumerator<(string NextStageName, object Result)> GenerateProceduralJobsCoroutineCore(StationProceduralJobsController instance, StationProceduralJobsRuleset stationProceduralJobsRuleset) {
+            var alreadyPresentJobsCount = instance.stationController.logicStation.availableJobs.Count;
+            var maxGeneratableJobsNum = stationProceduralJobsRuleset.jobsCapacity - alreadyPresentJobsCount;
             var generateJobsAttempts = 0;
             var forcePlayerLicensedJobGeneration = true;
-            Main._modEntry.Logger.Log($"{instance.stationController.stationInfo.YardID} job generation started. At most {stationProceduralJobsRuleset.jobsCapacity} job chains will be generated.");
-            while (instance.stationController.logicStation.availableJobs.Count < stationProceduralJobsRuleset.jobsCapacity && generateJobsAttempts < 30) {
+            Main._modEntry.Logger.Log($"{instance.stationController.stationInfo.YardID} job generation started. {alreadyPresentJobsCount} jobs already present. At most {maxGeneratableJobsNum} job chains will be generated.");
+            while (instance.stationController.logicStation.availableJobs.Count < maxGeneratableJobsNum && generateJobsAttempts < 30) {
                 yield return ("generate next job", WaitFor.FixedUpdate);
 
                 if (generateJobsAttempts > 10 & forcePlayerLicensedJobGeneration) {

--- a/PersistentJobsMod/CarSpawningJobGenerators/CarSpawningJobGenerator.cs
+++ b/PersistentJobsMod/CarSpawningJobGenerators/CarSpawningJobGenerator.cs
@@ -52,7 +52,7 @@ namespace PersistentJobsMod.CarSpawningJobGenerators {
                 }
             }
 
-            Main._modEntry.Logger.Log($"{instance.stationController.stationInfo.YardID} job generation ended. {instance.stationController.logicStation.availableJobs.Count} jobs were generated with {generateJobsAttempts} job generation attempts");
+            Main._modEntry.Logger.Log($"{instance.stationController.stationInfo.YardID} job generation ended. {instance.stationController.logicStation.availableJobs.Count - alreadyPresentJobsCount} jobs were generated with {generateJobsAttempts} job generation attempts");
 
             instance.generationCoro = null;
         }

--- a/PersistentJobsMod/Extensions/EnumerableExtensions.cs
+++ b/PersistentJobsMod/Extensions/EnumerableExtensions.cs
@@ -50,5 +50,35 @@ namespace PersistentJobsMod.Extensions {
 
             return (first, second);
         }
+
+        public static bool MultisetEquals<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer = null)
+        {
+            if (ReferenceEquals(first, second)) return true;
+            if (first == null || second == null) return false;
+
+            comparer ??= EqualityComparer<T>.Default;
+            var lookup = new Dictionary<T, int>(comparer);
+
+            foreach (var item in first)
+            {
+                if (lookup.TryGetValue(item, out int count))
+                    lookup[item] = count + 1;
+                else
+                    lookup[item] = 1;
+            }
+
+            foreach (var item in second)
+            {
+                if (!lookup.TryGetValue(item, out int count)) return false;
+
+                count--;
+                if (count == 0)
+                    lookup.Remove(item);
+                else
+                    lookup[item] = count;
+            }
+
+            return lookup.Count == 0;
+        }
     }
 }

--- a/PersistentJobsMod/Extensions/EnumerableExtensions.cs
+++ b/PersistentJobsMod/Extensions/EnumerableExtensions.cs
@@ -9,7 +9,7 @@ namespace PersistentJobsMod.Extensions {
         }
 
         public static IEnumerable<(TKey Key, IReadOnlyList<TItem> Items)> GroupConsecutiveBy<TKey, TItem>(this IEnumerable<TItem> items, Func<TItem, TKey> getKey, IEqualityComparer<TKey> keyEqualityComparer = null) {
-            keyEqualityComparer = keyEqualityComparer ?? EqualityComparer<TKey>.Default;
+            keyEqualityComparer ??= EqualityComparer<TKey>.Default;
 
             (TKey key, List<TItem> items)? current = null;
 
@@ -35,6 +35,20 @@ namespace PersistentJobsMod.Extensions {
 
         public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> enumerable) {
             return enumerable.ToList();
+        }
+
+        public static (List<T> First, List<T> Second) SplitInHalf<T>(this IEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            var list = source as IList<T> ?? source.ToList();
+
+            if (list.Count < 2) return (null, null);
+
+            int mid = (list.Count + 1) / 2;
+            var first = list.Take(mid).ToList();
+            var second = list.Skip(mid).ToList();
+
+            return (first, second);
         }
     }
 }

--- a/PersistentJobsMod/HarmonyPatches/CarSpawningJobGeneration/StationProceduralJobsController_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/CarSpawningJobGeneration/StationProceduralJobsController_Patch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using HarmonyLib;
 using PersistentJobsMod.CarSpawningJobGenerators;
+using PersistentJobsMod.ModInteraction;
 using PersistentJobsMod.Persistence;
 using UnityEngine;
 
@@ -18,6 +19,12 @@ namespace PersistentJobsMod.HarmonyPatches.CarSpawningJobGeneration {
                 if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(__instance.stationController)) {
                     Main._modEntry.Logger.Log($"Station {__instance.stationController.logicStation.ID} has already spawned cars, skipping jobs-with-cars generation");
                 } else {
+                    if (Main.PaxJobsPresent && PaxJobsCompat.AllPaxStations().Contains(__instance.stationController))
+                    {
+                        PaxJobsCompat.OverrideSpawnFlagForPaxJ = true;
+                        PaxJobsCompat.PaxJobsOrigGenJobsInStation(__instance.stationController.stationInfo.YardID);
+                    }
+
                     StationIdCarSpawningPersistence.Instance.SetHasStationSpawnedCarsFlag(__instance.stationController, true);
 
                     __instance.StopJobGeneration();

--- a/PersistentJobsMod/HarmonyPatches/Distance/StationController_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/Distance/StationController_Patches.cs
@@ -25,9 +25,12 @@ namespace PersistentJobsMod.HarmonyPatches.Distance {
         [HarmonyPatch(typeof(StationController), "Start")]
         public static void Start_Postfix(StationController __instance)
         {
-            var generateTrackSignsMethod = ReflectionUtilities.CompatAccess.Method(typeof(StationController), "GenerateTrackIdObject", new[] {typeof(List<RailTrack>) });
-            var tracksForGen = RailTrackRegistry.Instance.AllTracks.Where(rt => ((rt.LogicTrack().ID.yardId == __instance.stationInfo.YardID) && ((new string[] {"D", "P"}).Contains((string)ReflectionUtilities.CompatAccess.Field(typeof(TrackID), "trackType").GetValue(rt.LogicTrack().ID))))).ToList();
-            generateTrackSignsMethod.Invoke(__instance, new object[] {tracksForGen});
+            if (Main.Settings.GenerateTrackSigns)
+            {
+                var generateTrackSignsMethod = ReflectionUtilities.CompatAccess.Method(typeof(StationController), "GenerateTrackIdObject", new[] { typeof(List<RailTrack>) });
+                var tracksForGen = RailTrackRegistry.Instance.AllTracks.Where(rt => ((rt.LogicTrack().ID.yardId == __instance.stationInfo.YardID) && ((new string[] { "D", "P" }).Contains((string)ReflectionUtilities.CompatAccess.Field(typeof(TrackID), "trackType").GetValue(rt.LogicTrack().ID))))).ToList();
+                generateTrackSignsMethod.Invoke(__instance, new object[] { tracksForGen });
+            }
         }
     }
 }

--- a/PersistentJobsMod/HarmonyPatches/Distance/StationController_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/Distance/StationController_Patches.cs
@@ -1,4 +1,9 @@
-﻿using HarmonyLib;
+﻿using DV.Logic.Job;
+using HarmonyLib;
+using PersistentJobsMod.Utilities;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PersistentJobsMod.HarmonyPatches.Distance {
     /// <summary>prevents jobs from expiring due to the player's distance from the station</summary>
@@ -15,5 +20,14 @@ namespace PersistentJobsMod.HarmonyPatches.Distance {
         [HarmonyReversePatch]
         [HarmonyPatch(typeof(StationController), nameof(StationController.ExpireAllAvailableJobsInStation))]
         public static void ExpireAllAvailableJobsInStation_Original(StationController instance) { }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(StationController), "Start")]
+        public static void Start_Postfix(StationController __instance)
+        {
+            var generateTrackSignsMethod = ReflectionUtilities.CompatAccess.Method(typeof(StationController), "GenerateTrackIdObject", new[] {typeof(List<RailTrack>) });
+            var tracksForGen = RailTrackRegistry.Instance.AllTracks.Where(rt => ((rt.LogicTrack().ID.yardId == __instance.stationInfo.YardID) && ((new string[] {"D", "P"}).Contains((string)ReflectionUtilities.CompatAccess.Field(typeof(TrackID), "trackType").GetValue(rt.LogicTrack().ID))))).ToList();
+            generateTrackSignsMethod.Invoke(__instance, new object[] {tracksForGen});
+        }
     }
 }

--- a/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
@@ -114,6 +114,7 @@ namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
                 }
                 else Main._modEntry.Logger.Log($"Could not generate subsequent passanger jobs for {lastJobInChain.ID}");
             }
+            else Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job after completing an empty haul job.");
         }
 
         private static void FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(JobChainController subsequentJobChainController, JobChainController previousJobChainController, Job previousJob, bool finalize = true) {

--- a/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
@@ -1,12 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using DV.Logic.Job;
+﻿using DV.Logic.Job;
 using DV.ThingTypes;
 using DV.Utils;
 using HarmonyLib;
 using PersistentJobsMod.JobGenerators;
+using PersistentJobsMod.ModInteraction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+using static PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags;
+using static System.Collections.Specialized.BitVector32;
+using PassengerHaulJobDefinitionRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerHaulJobDefinition>;
 
 namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
     /// <summary>
@@ -40,15 +44,31 @@ namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
 
                     FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(subsequentJobChainController, __instance, lastJobInChain);
                 } else if (lastJobInChain.jobType == JobType.Transport && lastJobDefinition is StaticTransportJobDefinition transportJobDefinition) {
-                    var subsequentJobChainController = CreateSubsequentShuntingUnloadJob(__instance, transportJobDefinition);
-                    
-                    FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(subsequentJobChainController, __instance, lastJobInChain);
+                    if (Main.PaxJobsPresent && PaxJobsCompat.IsPaxCars(__instance.carsForJobChain.First().TrainCar()))
+                    {
+                        CreateSubsequentPaxJobs(__instance, transportJobDefinition, lastJobInChain);
+                    }
+                    else
+                    {
+                        var subsequentJobChainController = CreateSubsequentShuntingUnloadJob(__instance, transportJobDefinition);
+
+                        FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(subsequentJobChainController, __instance, lastJobInChain);
+                    }
                 } else if (lastJobInChain.jobType == JobType.ShuntingUnload && lastJobDefinition is StaticShuntingUnloadJobDefinition) {
                     // nothing to do. JobChainController will register the cars as jobless and they may then be chosen for further jobs
                     Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job after completing a shunting unload job.");
                 } else if (lastJobInChain.jobType == JobType.EmptyHaul && lastJobDefinition is StaticEmptyHaulJobDefinition) {
-                    // nothing to do. JobChainController will register the cars as jobless and they may then be chosen for further jobs
-                    Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job after completing an empty haul job.");
+                    if (Main.PaxJobsPresent)
+                    {
+                        CreateSubsequentPaxJobs(__instance, lastJobDefinition, lastJobInChain);
+                    }
+                    else
+                    {
+                        // nothing to do. JobChainController will register the cars as jobless and they may then be chosen for further jobs
+                        Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job after completing an empty haul job.");
+                    }
+                } else if (Main.PaxJobsPresent && PaxJobsCompat.IsPaxJobDefinition(lastJobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)) {
+                    CreateSubsequentPaxJobs(__instance, (StaticJobDefinition)passengerHaulJobDefinition.Value, lastJobInChain);
                 } else {
                     Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job for job type {lastJobInChain.jobType} and job definition type {lastJobDefinition.GetType()}.");
                 }
@@ -79,13 +99,30 @@ namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
             return ShuntingUnloadJobGenerator.TryGenerateJobChainController(startingStation, startingTrack, destinationStation, trainCars, rng);
         }
 
-        private static void FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(JobChainController subsequentJobChainController, JobChainController previousJobChainController, Job previousJob) {
+        private static void CreateSubsequentPaxJobs(JobChainController __instance, StaticJobDefinition preceedingJobDefinition, Job lastJobInChain)
+        {
+            List<JobChainController> subsequentJobChainControllers = new();
+
+            var trainCars = new List<TrainCar>(TrainCar.ExtractTrainCars(__instance.carsForJobChain));
+            if (!(trainCars.Any(tc => !PaxJobsCompat.IsPaxCars(tc))))
+            {
+                var destinationStation = SingletonBehaviour<LogicController>.Instance.YardIdToStationController[(preceedingJobDefinition.chainData.chainDestinationYardId)];
+                subsequentJobChainControllers.AddRange(PaxJobsCompat.DecideForPaxCarGroups((new List<IReadOnlyList<TrainCar>> { trainCars }), destinationStation));
+                if (subsequentJobChainControllers.Any() && !subsequentJobChainControllers.Any(jcc => jcc == null))
+                {
+                    foreach (var subsequentJobChainController in subsequentJobChainControllers) FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(subsequentJobChainController, __instance, lastJobInChain, finalize: false);
+                }
+                else Main._modEntry.Logger.Log($"Could not generate subsequent passanger jobs for {lastJobInChain.ID}");
+            }
+        }
+
+        private static void FinishSubsequentJobChainControllerAndRemoveTrainCarsFromCurrentJobChain(JobChainController subsequentJobChainController, JobChainController previousJobChainController, Job previousJob, bool finalize = true) {
             if (subsequentJobChainController != null) {
                 foreach (var tc in subsequentJobChainController.carsForJobChain) {
                     previousJobChainController.carsForJobChain.Remove(tc);
                 }
 
-                subsequentJobChainController.FinalizeSetupAndGenerateFirstJob();
+                if (finalize) subsequentJobChainController.FinalizeSetupAndGenerateFirstJob();
 
                 if (subsequentJobChainController.currentJobInChain is Job job) {
                     Main._modEntry.Logger.Log($"Completion of job {previousJob.ID} generated subsequent {job.jobType} job {job.ID} ({subsequentJobChainController.jobChainGO.name})");

--- a/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobChainControllers/JobChainController_OnLastJobInChainCompleted_Patch.cs
@@ -29,9 +29,15 @@ namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
 
             if (!__instance.carsForJobChain.Any()) {
                 // passenger jobs may generate a subsequent job by themselves, thereby clearing trainCarsForJobChain
+                Main._modEntry.Logger.Log("carsForJobChain is clear for job " +  lastJobInChain.ID);
                 return;
             }
 
+            DecideForConsistAfterJobChainCompletion(__instance, ___jobChain, lastJobInChain);
+        }
+
+        public static void DecideForConsistAfterJobChainCompletion(JobChainController __instance, List<StaticJobDefinition> ___jobChain, Job lastJobInChain)
+        {
             try {
                 var lastJobDefinition = ___jobChain[___jobChain.Count - 1];
                 if (lastJobDefinition.job != lastJobInChain) {
@@ -73,7 +79,7 @@ namespace PersistentJobsMod.HarmonyPatches.JobChainControllers {
                     Debug.Log($"[PersistentJobsMod] Skipped creating a subsequent job for job type {lastJobInChain.jobType} and job definition type {lastJobDefinition.GetType()}.");
                 }
             } catch (Exception e) {
-                Main.HandleUnhandledException(e, nameof(JobChainController_OnLastJobInChainCompleted_Patch) + "." + nameof(Prefix));
+                Main.HandleUnhandledException(e, nameof(JobChainController_OnLastJobInChainCompleted_Patch) + "." + nameof(Prefix) + " -->" + nameof(DecideForConsistAfterJobChainCompletion));
             }
         }
 

--- a/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/JobGeneration/UnusedTrainCarDeleter_Patches.cs
@@ -208,8 +208,7 @@ namespace PersistentJobsMod.HarmonyPatches.JobGeneration {
 
             Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
             Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
-            if (Main.PaxJobsPresent && ((paxConsecutiveTrainCarGroups.SelectMany(g => g).Count() + emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count() + loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()) != trainsets.SelectMany(ts => ts.cars).Count())) Main._modEntry.Logger.Error($"Mismatch in number of cars! Trainset cars: {trainsets.SelectMany(ts => ts.cars).Count()}; Pax cars: {paxConsecutiveTrainCarGroups.SelectMany(g => g).Count()}; empty cars: {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()}; loaded cars: {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()}");
-
+            
             var (loadableConsecuteTrainCarGroups, notLoadableConsecutiveTrainCarGroups) = DivideEmptyConsecutiveTrainCarGroupsIntoLoadableAndNotLoadable(station, emptyConsecutiveTrainCarGroups);
             var (unloadableConsecutiveTrainCarGroups, notUnloadableConsecutiveTrainCarGroups) = DivideLoadedConsecutiveTrainCarGroupsIntoUnloadableAndNotUnloadable(station, loadedConsecutiveTrainCarGroups);
 

--- a/PersistentJobsMod/HarmonyPatches/Save/CarsSaveManager_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/CarsSaveManager_Patches.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using System.Linq;
-using System.Collections;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Newtonsoft.Json.Linq;
 using PersistentJobsMod.Persistence;
+using PersistentJobsMod.Utilities;
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Linq;
 using UnityEngine;
 
 namespace PersistentJobsMod.HarmonyPatches.Save
@@ -17,7 +19,7 @@ namespace PersistentJobsMod.HarmonyPatches.Save
             //if no car data is loaded (eg. game update reset them), expire all jobs and allow new cars to re-spawn 
             if (__result == false)
             {
-                Debug.Log($"No savegame data found, possibly due to game update. Resetting all jobs and stations.");
+                Main._modEntry.Logger.Warning($"CarsSaveManager_Patches.Load.Postfix: No savegame data found, possibly due to game update. Resetting all jobs and stations.");
                 ResetJobsAndCarsState();
             }
             try
@@ -45,6 +47,7 @@ namespace PersistentJobsMod.HarmonyPatches.Save
             catch (Exception e)
             {
                 Main._modEntry.Logger.Warning($"Loading mod data failed with exception:\n{e}");
+                ResetJobsAndCarsState();
             }
         }
 
@@ -61,6 +64,9 @@ namespace PersistentJobsMod.HarmonyPatches.Save
 
         public static void ResetJobsAndCarsState()
         {
+            Main._modEntry.Logger.Warning("Faliure in job loading, reseting all jobs and stations");
+            StackTrace trace = new(true);
+            Main._modEntry.Logger.Log("Callstack: \n" + trace.ToString());
             PersistentJobsMod.Console.ExpireAvailableJobsInAllStations();
             StationIdCarSpawningPersistence.Instance.ClearStationsSpawnedCarsFlagForAllStations();
             SaveGameManager.Instance.StartCoroutine(GenerateJobsCurrentStationCoroutine());
@@ -72,8 +78,12 @@ namespace PersistentJobsMod.HarmonyPatches.Save
     {
         public static void Postfix()
         {
-            Main._modEntry.Logger.Log($"Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
-            CarsSaveManager_Patches.ResetJobsAndCarsState();
+
+            if (ReflectionUtilities.IsInCallers(methodName: "LoadingNonBlockingCoro", excludeMethodName: "Manager.Load_Patch", specificFrameNumeric: "", log: false))
+            {
+                Main._modEntry.Logger.Log($" CarsSaveManager_DeleteAllExistingCars_Patch.Postfix: Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
+                CarsSaveManager_Patches.ResetJobsAndCarsState();
+            }
         }
     }
 }

--- a/PersistentJobsMod/HarmonyPatches/Save/CarsSaveManager_Patches.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/CarsSaveManager_Patches.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using System.Collections;
+using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using PersistentJobsMod.Persistence;
+using UnityEngine;
+
+namespace PersistentJobsMod.HarmonyPatches.Save
+{
+    /// <summary>patch CarsSaveManager.Load to ensure CarsSaveManager.TracksHash exists</summary>
+    [HarmonyPatch(typeof(CarsSaveManager), "Load")]
+    public static class CarsSaveManager_Patches
+    {
+        public static void Postfix(ref bool __result)
+        {
+            //if no car data is loaded (eg. game update reset them), expire all jobs and allow new cars to re-spawn 
+            if (__result == false)
+            {
+                Debug.Log($"No savegame data found, possibly due to game update. Resetting all jobs and stations.");
+                ResetJobsAndCarsState();
+            }
+            try
+            {
+                var saveData = SaveGameManager.Instance.data.GetJObject(SaveDataConstants.SAVE_DATA_PRIMARY_KEY);
+
+                if (saveData == null)
+                {
+                    Main._modEntry.Logger.Log("Not loading save data: primary object is null.");
+                    return;
+                }
+
+                var spawnBlockSaveData = (JArray)saveData[$"{SaveDataConstants.SAVE_DATA_SPAWN_BLOCK_KEY}#{SaveDataConstants.TRACK_HASH_SAVE_KEY}"];
+                if (spawnBlockSaveData == null)
+                {
+                    Main._modEntry.Logger.Log("Not loading spawn block list: data is null.");
+                }
+                else
+                {
+                    var alreadySpawnedCarsStatioinIds = spawnBlockSaveData.Select(id => (string)id).ToList();
+                    StationIdCarSpawningPersistence.Instance.HandleSavegameLoadedSpawnedStationIds(alreadySpawnedCarsStatioinIds);
+                    Main._modEntry.Logger.Log($"Loaded station spawn block list: [ {string.Join(", ", alreadySpawnedCarsStatioinIds)} ]");
+                }
+            }
+            catch (Exception e)
+            {
+                Main._modEntry.Logger.Warning($"Loading mod data failed with exception:\n{e}");
+            }
+        }
+
+        public static IEnumerator GenerateJobsCurrentStationCoroutine()
+        {
+            while (PlayerManager.PlayerTransform == null)
+            {
+                yield return null;
+            }
+            var station = StationController.allStations.OrderBy(sc => (PlayerManager.PlayerTransform.position - sc.gameObject.transform.position).sqrMagnitude).First();
+            station.ProceduralJobsController.TryToGenerateJobs();
+            StationIdCarSpawningPersistence.Instance.SetHasStationSpawnedCarsFlag(station, true);
+        }
+
+        public static void ResetJobsAndCarsState()
+        {
+            PersistentJobsMod.Console.ExpireAvailableJobsInAllStations();
+            StationIdCarSpawningPersistence.Instance.ClearStationsSpawnedCarsFlagForAllStations();
+            SaveGameManager.Instance.StartCoroutine(GenerateJobsCurrentStationCoroutine());
+        }
+    }
+
+    [HarmonyPatch(typeof(CarsSaveManager), "DeleteAllExistingCars")]
+    public static class CarsSaveManager_DeleteAllExistingCars_Patch
+    {
+        public static void Postfix()
+        {
+            Main._modEntry.Logger.Log($"Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
+            CarsSaveManager_Patches.ResetJobsAndCarsState();
+        }
+    }
+}

--- a/PersistentJobsMod/HarmonyPatches/Save/SaveGameData_RemoveData_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/SaveGameData_RemoveData_Patch.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 namespace PersistentJobsMod.HarmonyPatches.Save
 {
     [HarmonyPatch(typeof(SaveGameData), "RemoveData")]
-    public static class SaveGameManager_RemoveData_Patch
+    public static class SaveGameData_RemoveData_Patch
     {
         public static void Postfix(string key)
         {
             if ((key == SaveGameKeys.Cars) || (key == SaveGameKeys.Jobs))
             {
-                Main._modEntry.Logger.Log($"Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
+                Main._modEntry.Logger.Log($"SaveGameData_RemoveData_Patch.Postfix: Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
                 CarsSaveManager_Patches.ResetJobsAndCarsState();
             }
         }

--- a/PersistentJobsMod/HarmonyPatches/Save/SaveGameManager_RemoveData_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/SaveGameManager_RemoveData_Patch.cs
@@ -10,9 +10,9 @@ namespace PersistentJobsMod.HarmonyPatches.Save
     [HarmonyPatch(typeof(SaveGameData), "RemoveData")]
     public static class SaveGameManager_RemoveData_Patch
     {
-        public static void Postfix(string _result)
+        public static void Postfix(string key)
         {
-            if ((_result == SaveGameKeys.Cars) || (_result == SaveGameKeys.Jobs))
+            if ((key == SaveGameKeys.Cars) || (key == SaveGameKeys.Jobs))
             {
                 Main._modEntry.Logger.Log($"Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
                 CarsSaveManager_Patches.ResetJobsAndCarsState();

--- a/PersistentJobsMod/HarmonyPatches/Save/SaveGameManager_RemoveData_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/SaveGameManager_RemoveData_Patch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PersistentJobsMod.HarmonyPatches.Save
+{
+    [HarmonyPatch(typeof(SaveGameData), "RemoveData")]
+    public static class SaveGameManager_RemoveData_Patch
+    {
+        public static void Postfix(string _result)
+        {
+            if ((_result == SaveGameKeys.Cars) || (_result == SaveGameKeys.Jobs))
+            {
+                Main._modEntry.Logger.Log($"Savegame data reset, possibly due to mod or game update. Resetting all jobs and stations.");
+                CarsSaveManager_Patches.ResetJobsAndCarsState();
+            }
+        }
+    }
+}

--- a/PersistentJobsMod/HarmonyPatches/Save/StartGameData_FromSaveGame_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/StartGameData_FromSaveGame_Patch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PersistentJobsMod.HarmonyPatches.Save
+{
+    [HarmonyPatch(typeof(StartGameData_FromSaveGame), "GetPostLoadMessage")]
+    public static class StartGameData_FromSaveGame_Patch
+    {
+        public static void Postfix(string __result)
+        {
+            if(__result == "tutorial/trains_were_reset")
+            {
+                CarsSaveManager_Patches.ResetJobsAndCarsState();
+            }
+        }
+    }
+}

--- a/PersistentJobsMod/HarmonyPatches/Save/WorldStreaminInit_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/WorldStreaminInit_Patch.cs
@@ -1,5 +1,8 @@
-﻿using HarmonyLib;
+﻿using DV.Utils;
+using HarmonyLib;
+using MessageBox;
 using PersistentJobsMod.Persistence;
+using System.Collections;
 
 namespace PersistentJobsMod.HarmonyPatches.Save {
     [HarmonyPatch]
@@ -9,6 +12,24 @@ namespace PersistentJobsMod.HarmonyPatches.Save {
         public static void LoadingRoutine_Prefix() {
             Main._modEntry.Logger.Log("WorldStreamingInit.LoadingRoutine prefix: Cleared station spawn flags");
             StationIdCarSpawningPersistence.Instance.ClearStationsSpawnedCarsFlagForAllStations();
+        }
+
+        [HarmonyPatch(typeof(WorldStreamingInit), "LoadingRoutine")]
+        [HarmonyPostfix]
+        public static IEnumerator LoadingRoutine_Postfix(IEnumerator __result)
+        {
+            if (Main.PaxJobsPresent)
+            {
+                while (__result.MoveNext()) yield return __result.Current;
+
+                yield return WaitFor.Seconds(2f);
+
+                if ((Main.PaxJobs != null) && !Main.PaxJobsPresent)
+                {
+                    Main._modEntry.Logger.Log("PaxJobsCompat not active, showing message to player");
+                    PopupAPI.ShowOk($"Passenger Jobs mod v{Main.PaxJobs.Version} is present but the Persistent Jobs compatibility layer is not loaded. \nThis is probably due to a recent update (check mod pages or ask on the Altfuture discord). \nThe game should be in a playable state, but new passenger jobs may not be generated \nand cars will remain jobless.");
+                }
+            }
         }
     }
 }

--- a/PersistentJobsMod/HarmonyPatches/Save/WorldStreaminInit_Patch.cs
+++ b/PersistentJobsMod/HarmonyPatches/Save/WorldStreaminInit_Patch.cs
@@ -1,8 +1,8 @@
-﻿using DV.Utils;
-using HarmonyLib;
+﻿using HarmonyLib;
 using MessageBox;
 using PersistentJobsMod.Persistence;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace PersistentJobsMod.HarmonyPatches.Save {
     [HarmonyPatch]
@@ -17,19 +17,22 @@ namespace PersistentJobsMod.HarmonyPatches.Save {
         [HarmonyPatch(typeof(WorldStreamingInit), "LoadingRoutine")]
         [HarmonyPostfix]
         public static IEnumerator LoadingRoutine_Postfix(IEnumerator __result)
-        {
-            if (Main.PaxJobsPresent)
+        {   
+            while (__result.MoveNext()) yield return __result.Current;
+
+            foreach (var popup in stringsToShow)
             {
-                while (__result.MoveNext()) yield return __result.Current;
-
                 yield return WaitFor.Seconds(2f);
-
-                if ((Main.PaxJobs != null) && !Main.PaxJobsPresent)
-                {
-                    Main._modEntry.Logger.Log("PaxJobsCompat not active, showing message to player");
-                    PopupAPI.ShowOk($"Passenger Jobs mod v{Main.PaxJobs.Version} is present but the Persistent Jobs compatibility layer is not loaded. \nThis is probably due to a recent update (check mod pages or ask on the Altfuture discord). \nThe game should be in a playable state, but new passenger jobs may not be generated \nand cars will remain jobless.");
-                }
-            }
+                PopupAPI.ShowOk(popup);
+            }           
         }
+
+        public static void ShowPopupOnPlayerSpawn(string message)
+        {
+            stringsToShow.Add(message);
+            Main._modEntry.Logger.Log($"Message added to queue: \"{message}\" ");
+        }
+
+        private static readonly List<string> stringsToShow = new();
     }
 }

--- a/PersistentJobsMod/JobGenerators/EmptyHaulJobGenerator.cs
+++ b/PersistentJobsMod/JobGenerators/EmptyHaulJobGenerator.cs
@@ -10,14 +10,17 @@ using PersistentJobsMod.Licensing;
 namespace PersistentJobsMod.JobGenerators {
     [HarmonyPatch]
     public static class EmptyHaulJobGenerator {
-        public static JobChainController GenerateEmptyHaulJobWithExistingCarsOrNull(StationController startingStation, StationController destinationStation, Track startingTrack, IReadOnlyList<TrainCar> trainCars, Random random) {
+        public static JobChainController GenerateEmptyHaulJobWithExistingCarsOrNull(StationController startingStation, StationController destinationStation, Track startingTrack, IReadOnlyList<TrainCar> trainCars, Random random, Track targetTrack = null) {
             Main._modEntry.Logger.Log($"empty haul: attempting to generate {JobType.EmptyHaul} job from {startingStation.logicStation.ID} to {destinationStation.logicStation.ID} for {trainCars.Count} cars");
 
             var trainCarLiveries = trainCars.Select(tc => tc.carLivery).ToList();
 
             var trainLength = CarSpawner.Instance.GetTotalCarLiveriesLength(trainCarLiveries);
-            var targetTrack = GetTargetTrackOrNull(destinationStation, trainLength, random);
-            if (targetTrack == null) {
+            targetTrack ??= GetTargetTrackOrNull(destinationStation, trainLength, random);
+            if (targetTrack == null) return null;
+            if ((targetTrack.ID.yardId != destinationStation.stationInfo.YardID) || (startingTrack.ID.yardId != startingStation.stationInfo.YardID))
+            {
+                Main._modEntry.Logger.Error($"Mismatch between track and station, this should not happen!");
                 return null;
             }
 

--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -53,6 +53,7 @@ namespace PersistentJobsMod {
                 {
                     PaxJobsPresent = false;
                     _modEntry.Logger.Error("Passanger Jobs compatibility failed to load!");
+                    HarmonyPatches.Save.WorldStreaminInit_Patch.ShowPopupOnPlayerSpawn($"Passenger Jobs mod v{PaxJobs.Version} is present but the Persistent Jobs compatibility layer is not loaded. \nThis is probably due to a recent update (check mod pages or ask on the Altfuture discord). \nThe game should be in a playable state, but new passenger jobs may not be generated \nand cars will remain jobless.");
                 }
             }
             else

--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -2,6 +2,7 @@
 using MessageBox;
 using PersistentJobsMod.Model;
 using PersistentJobsMod.ModInteraction;
+using PersistentJobsMod.Utilities;
 using System;
 using System.IO;
 using System.Linq;
@@ -53,7 +54,7 @@ namespace PersistentJobsMod {
                 {
                     PaxJobsPresent = false;
                     _modEntry.Logger.Error("Passanger Jobs compatibility failed to load!");
-                    HarmonyPatches.Save.WorldStreaminInit_Patch.ShowPopupOnPlayerSpawn($"Passenger Jobs mod v{PaxJobs.Version} is present but the Persistent Jobs compatibility layer is not loaded. \nThis is probably due to a recent update (check mod pages or ask on the Altfuture discord). \nThe game should be in a playable state, but new passenger jobs may not be generated \nand cars will remain jobless.");
+                    HarmonyPatches.Save.WorldStreaminInit_Patch.ShowPopupOnPlayerSpawn($"Passenger Jobs mod v{PaxJobs.Version} is present but the Persistent Jobs compatibility layer is not loaded. \nThis is probably due to a recent update (check mod pages or ask on the Altfuture discord). \nThe game should be in a playable state,\n but new passenger jobs may not be generated and cars will remain jobless.");
                 }
             }
             else
@@ -87,16 +88,9 @@ namespace PersistentJobsMod {
             _isModBroken = true;
             _modEntry.Active = false;
 
-            var logMessage = $"Exception thrown at {location}:\n{e}";
-            Debug.LogError(logMessage);
-
-            var exceptionLogFilename = $"PersistentJobsMod_Exception_{DateTime.Now.ToString("O").Replace(':', '.')}.log";
-            var logExceptionFilepath = Path.Combine(Application.persistentDataPath, exceptionLogFilename);
-            File.WriteAllText(logExceptionFilepath, logMessage);
-
             _modEntry.Logger.Critical($"Deactivating mod PersistentJobsMod due to critical exception in {location}:\n{e}");
 
-            PopupAPI.ShowOk($"Persistent Jobs mod encountered a critical failure. The mod will stay inactive until the game is restarted.\n\nSee {exceptionLogFilename} for details.");
+            AddMoreInfoToExceptionHelper.AlertPlayerToExceptionAndCompileDataForBugReport(e, location);
         }
     }
 }

--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -13,6 +13,7 @@ namespace PersistentJobsMod {
     public static class Main {
         // ReSharper disable InconsistentNaming
         public static UnityModManager.ModEntry _modEntry;
+        public static Harmony Harmony;
         public static float _initialDistanceRegular = 0f;
         public static float _initialDistanceAnyJobTaken = 0f;
         // ReSharper restore InconsistentNaming
@@ -32,8 +33,8 @@ namespace PersistentJobsMod {
         public static void Load(UnityModManager.ModEntry modEntry) {
             _modEntry = modEntry;
 
-            var harmony = new Harmony(modEntry.Info.Id);
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
+            Harmony = new Harmony(modEntry.Info.Id);
+            Harmony.PatchAll(Assembly.GetExecutingAssembly());
 
             Settings = UnityModManager.ModSettings.Load<Settings>(modEntry);
 

--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -44,7 +44,7 @@ namespace PersistentJobsMod {
 
             WorldStreamingInit.LoadingFinished += WorldStreamingInitLoadingFinished;
 
-            PaxJobs = UnityModManager.modEntries.FirstOrDefault(m => m.Info.Id == "PassengerJobs" && m.Enabled && m.Active && !m.ErrorOnLoading && m.Version.ToString() == "5.1.1");
+            PaxJobs = UnityModManager.modEntries.FirstOrDefault(m => m.Info.Id == "PassengerJobs" && m.Enabled && m.Active && !m.ErrorOnLoading /*&& m.Version.ToString() == "5.2"*/);
             PaxJobsPresent = (PaxJobs != null);
             if (PaxJobsPresent)
             {
@@ -57,7 +57,7 @@ namespace PersistentJobsMod {
             }
             else
             {
-                _modEntry.Logger.Log($"Targeted version of Passanger Jobs (5.1.1) is not present, inactive, or has ran into errors, skipping mod compatibility");
+                _modEntry.Logger.Log($"Targeted version of optional mod Passanger Jobs (5.2) is not present, inactive, or has ran into errors, skipping mod compatibility");
             }
         }
 

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -225,17 +225,16 @@ namespace PersistentJobsMod.ModInteraction
 
         public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
         {
-            foreach (var trainCars in trainCarGroups)
+            trainCarGroups.RemoveAll(trainCars =>
             {
-                if (trainCars == null || trainCars.Count() < 1)
+                if (trainCars == null || trainCars.Count < 1)
                 {
                     Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid trainCars input thrown out");
-                    trainCarGroups.Remove(trainCars);
+                    return true; // Remove
                 }
-
                 var startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-                if (startingTrack == null) trainCarGroups.Remove(trainCars);
-            }
+                return startingTrack == null; // Remove if null
+            });
             return trainCarGroups;
         }
 

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -1,0 +1,316 @@
+﻿using DV;
+using DV.Logic.Job;
+using DV.ThingTypes;
+using PersistentJobsMod.Extensions;
+using PersistentJobsMod.HarmonyPatches.JobGeneration;
+using PersistentJobsMod.JobGenerators;
+using PersistentJobsMod.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
+using Random = System.Random;
+
+namespace PersistentJobsMod.ModInteraction
+{
+    public static class PaxJobsCompat
+    {
+        private static Assembly asm;
+
+        private static Type _RouteManager;
+        private static Type _ConsistManger;
+        private static Type _RouteTrack;
+        private static Type _PassConsistInfo;
+        private static Type _PassengerJobGenerator;
+        private static Type _IPassDestination;
+
+        private static ConstructorInfo _RouteTrackCtor;
+        private static ConstructorInfo _PassConsistInfoCtor;
+
+        private static MethodInfo TryGetInstance;
+        private static MethodInfo GenerateJob;
+
+        private static Random _Random;
+
+        public static bool Initialize()
+        {
+            try
+            {
+                asm = Main.PaxJobs.Assembly;
+                _RouteManager = asm.GetType("PassengerJobs.Generation.RouteManager");
+                _ConsistManger = asm.GetType("PassengerJobs.Generation.ConsistManager");
+                _RouteTrack = asm.GetType("PassengerJobs.Generation.RouteTrack");
+                _PassConsistInfo = asm.GetType("PassengerJobs.Generation.PassConsistInfo");
+                _PassengerJobGenerator = asm.GetType("PassengerJobs.Generation.PassengerJobGenerator");
+                _IPassDestination = asm.GetType("PassengerJobs.Generation.IPassDestination");
+
+                TryGetInstance = _PassengerJobGenerator.GetMethod("TryGetInstance", BindingFlags.Public | BindingFlags.Static);
+                GenerateJob = _PassengerJobGenerator.GetMethod("GenerateJob", BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(JobType), _PassConsistInfo }, null);
+
+                _Random = new Random();
+            }
+            catch (Exception e)
+            {
+                Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods", e);
+                return false;
+            }
+            return true;
+        }
+
+        public static bool TryGetGenerator(string yardId, out object generator)
+        {
+            generator = null;
+            var args = new object[] { yardId, null };
+            if (!(bool)TryGetInstance.Invoke(null, args))
+            {
+                Main._modEntry.Logger.Error($"Couldn´t get instance of PaxJobsGenerator for {yardId}");
+                return false;
+            }
+
+            generator = args[1];
+            return generator != null;
+        }
+
+        public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out object passengerChainController)
+        {
+            Main._modEntry.Logger.Log($"[TryGenerateJob] Attempting to generate job of type {jobType} in {yardId}");
+            passengerChainController = null;
+            if (!TryGetGenerator(yardId, out object generator))
+            {
+                Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
+                return false;
+            }
+
+            passengerChainController = GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });
+            if (passengerChainController == null) Main._modEntry.Logger.Error("Couldn´t generate PaxJob - null from there");
+            return passengerChainController != null;
+        }
+
+        public static object CreateRouteTrack(object IPassDestination, Track terminalTrack)
+        {
+            _RouteTrackCtor = _RouteTrack.GetConstructor(new[] { _IPassDestination, typeof(Track) });
+            return _RouteTrackCtor.Invoke(new object[] { IPassDestination, terminalTrack });
+        }
+
+        public static object CreatePassConsistInfo(object routeTrack, List<Car> cars)
+        {
+            _PassConsistInfoCtor = _PassConsistInfo.GetConstructor(new[] { _RouteTrack, typeof(List<Car>) });
+            return _PassConsistInfoCtor.Invoke(new object[] { routeTrack, cars });
+        }
+
+        public static bool IsPaxCars(TrainCar car)
+        {
+            var GetPassengerCars = _ConsistManger?.GetMethod("GetPassengerCars", BindingFlags.Public | BindingFlags.Static);
+            IEnumerable<TrainCarLivery> carLiveries = (IEnumerable<TrainCarLivery>)(GetPassengerCars?.Invoke(null, null));
+            return (carLiveries != null && car.carLivery != null) && carLiveries.Contains(car.carLivery);
+        }
+
+        public static bool IsPassengerStation(string yardId)
+        {
+            var IsPassengerStation = _RouteManager.GetMethod("IsPassengerStation", BindingFlags.Public | BindingFlags.Static);
+            return (bool)(IsPassengerStation?.Invoke(null, new object[] { yardId }));
+        }
+
+        public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
+
+        public static object GetStationData(string yardId)
+        {
+            var GetStationData = _RouteManager.GetMethod("GetStationData", BindingFlags.Public | BindingFlags.Static);
+            return /*IPassDestination : PassStationData*/GetStationData?.Invoke(null, new object[] { yardId });
+        }
+
+        public static List<Track> AllPaxTracksForStationData(string yardId)
+        {
+            PropertyInfo _allTracksProperty = _IPassDestination.GetProperty("AllTracks", BindingFlags.Public | BindingFlags.Instance);
+            return ((IEnumerable<Track>)_allTracksProperty.GetValue(GetStationData(yardId))).ToList();
+        }
+
+        public static IEnumerable<object> GetPlatforms(object stationData, bool onlyTerminusTracks = false)
+        {
+            var _getPlatformsMethod = _IPassDestination.GetMethod("GetPlatforms", BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(bool) }, null);
+
+            var result = _getPlatformsMethod.Invoke(stationData, new object[] { onlyTerminusTracks });
+
+            // "Cast to non-generic IEnumerable, which works for both struct and class collections" <-- AI´s fix of one runtime crash, I don´t understand this fully...
+            if (result is System.Collections.IEnumerable enumerable)
+            {
+                foreach (var item in enumerable)
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        public static Track GetRouteTractTrackField(object routeTrack)
+        {
+            FieldInfo RouteTrackTrackField = _RouteTrack.GetField("Track", BindingFlags.Public | BindingFlags.Instance);
+            return (Track)RouteTrackTrackField.GetValue(routeTrack);
+        }
+
+        public static double GetRouteTrackLength(object routeTrack)
+        {
+            PropertyInfo lengthProp = _RouteTrack.GetProperty("Length", BindingFlags.Public | BindingFlags.Instance);
+            return (double)lengthProp.GetValue(routeTrack);
+        }
+
+        public static bool CanFitInPaxStation(StationController paxStation, List<TrainCar> trainCars)
+        {
+            var stationData = GetStationData(paxStation.stationInfo.YardID);
+            var platforms = GetPlatforms(stationData).ToList();
+            if (platforms == null || !platforms.Any()) return false;
+            float carsLength = CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true);
+            return platforms.Any(p => carsLength < GetRouteTrackLength(p));
+        }
+
+        public static (List<IReadOnlyList<TrainCar>>, List<IReadOnlyList<TrainCar>>) SortCGIntoEmptyAndLoaded(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups)
+        {
+            var statusTrainCarGroups = paxConsecutiveTrainCarGroups.SelectMany(cars => cars.GroupConsecutiveBy(tc => UnusedTrainCarDeleter_Patches.GetTrainCarReassignStatus(tc))).ToList();
+            var emptyConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Empty).Select(s => s.Items).ToList();
+            var loadedConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Loaded).Select(s => s.Items).ToList();
+
+            Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+            Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+            return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
+        }
+        public static void DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
+        {
+            Main._modEntry.Logger.Log($"Reassigning passanger cars to jobs in station {station.logicStation.ID}");
+
+            foreach (var trainCar in paxConsecutiveTrainCarGroups.SelectMany(tcg => tcg))
+            {
+                PlayerSpawnedCarUtilities.ConvertPlayerSpawnedTrainCar(trainCar);
+            }
+
+            var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(paxConsecutiveTrainCarGroups);
+            foreach (List<TrainCar> tcs in emptyConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+            {
+                HandleEmptyPaxCars(tcs, station);
+            }
+            foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+            {
+                Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
+                //handling complicated - no inbuilt methods for job generation from already loaded cars
+            }
+        }
+
+        public static (List<T> first, List<T> second) SplitInHalf<T>(IList<T> source)
+        {
+            if (source.Count() < 2) return (null, null);
+            int mid = (source.Count + 1) / 2;
+            var first = source.Take(mid).ToList();
+            var second = source.Skip(mid).ToList();
+            return (first, second);
+        }
+
+
+        public static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station)
+        {
+            if (trainCars == null || trainCars.Count() < 1)
+            {
+                Main._modEntry.Logger.Error("[HandleEmptyPaxCars] Invalid trainCars input");
+                return;
+            }
+
+            var startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+            if (startingTrack == null) return;
+
+            if (IsPassengerStation(station.stationInfo.YardID))
+            {
+                //generate PaxJob: need to create PassConsistInfo from RouteTrack
+                Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} ready for pax job reassignment");
+
+                var stationData = GetStationData(station.stationInfo.YardID);
+                List<Track> platformTracks = GetPlatforms(stationData).Select(GetRouteTractTrackField).ToList();
+                if (platformTracks == null || !platformTracks.Any())
+                {
+                    Main._modEntry.Logger.Error($"[HandleEmptyPaxCars] Station {station.stationInfo.YardID} is marked as passanger but has no accesable platforms, this should not happen!");
+                    return;
+                }
+
+                bool canFitSomewhere = CanFitInPaxStation(station, trainCars);
+                JobType jobType = 0;
+                if (!canFitSomewhere && trainCars.Count >= 2)
+                {
+                    Main._modEntry.Logger.Log($"Consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t fit into any platform in {station.stationInfo.YardID}, attempting to split");
+                    var (first, second) = SplitInHalf(trainCars);
+                    HandleEmptyPaxCars(first, station);
+                    HandleEmptyPaxCars(second, station);
+                    return;
+                }
+                else if (!canFitSomewhere && trainCars.Count < 2)
+                {
+                    Main._modEntry.Logger.Error($"Consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be assigned to any platform in {station.stationInfo.YardID}, this shouldn´t happen! (You should check station data");
+                    return;
+                }
+                else if (canFitSomewhere && trainCars.Count <= 4)
+                {
+                    jobType = (JobType)_Random.Next(101, 103);
+                }
+                else if (canFitSomewhere && trainCars.Count() > 4)
+                {
+                    jobType = (JobType)101;
+                }
+                Main._modEntry.Logger.Log($"Picked JobType is {jobType}");
+
+                if (jobType != 0 && platformTracks.Contains(startingTrack) && (CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true) < startingTrack.length))
+                {
+                    var consistInfo = CreatePassConsistInfo(CreateRouteTrack(stationData, startingTrack), TrainCar.ExtractLogicCars(trainCars));
+                    var haveChainController = TryGenerateJob(station.stationInfo.YardID, jobType, consistInfo, out object passengerChainController);
+                    if (haveChainController)
+                    {
+                        Main._modEntry.Logger.Log($"Succesfully reassigned consist of pax cars starting with {trainCars.First().ID} to a job {null /*need to get job info from generated chain controller*/}");
+                    }
+                    else Main._modEntry.Logger.Log($"Could not reassign consist of pax cars starting with {trainCars.First().ID} to a job");
+                    return;
+                }
+                else
+                {
+                    if ((int)jobType != 101 && (int)jobType != 102)
+                    {
+                        Main._modEntry.Logger.Error($"Picked JobType ({jobType}) is currently not valid, this should not happen!");
+                        return;
+                    }
+                    else
+                    {
+                        Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on (non-platform ? ) track {startingTrack.ID.FullID} need handling");
+                        //not an ideal solution, setting starting track to one of the platforms regardless of trainCars positions
+                        var alternateStartingTrack = (GetPlatforms(stationData).Select(GetRouteTractTrackField).ToList()).Where(t => t.length < CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true)).ToList().GetRandomElement();
+                        var consistInfo = CreatePassConsistInfo(CreateRouteTrack(stationData, alternateStartingTrack), TrainCar.ExtractLogicCars(trainCars));
+                        var haveChainController = TryGenerateJob(station.stationInfo.YardID, jobType, consistInfo, out object passengerChainController);
+                        if (haveChainController)
+                        {
+                            Main._modEntry.Logger.Log($"Succesfully reassigned consist of pax cars starting with {trainCars.First().ID} to a job {null /*need to get job info from generated chain controller*/}");
+                        }
+                        else Main._modEntry.Logger.Log($"Could not reassign consist of pax cars starting with {trainCars.First().ID} to a job");
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned");
+                //generate LH job to random pax station: use already existing mod logic elswhere -- potentially chnge to use SP tracks which PaxJobs currently doesn´t - waiting for update
+                StationController viableDestStation = AllPaxStations().Distinct().Where(st => st != station).Where(st => CanFitInPaxStation(st, trainCars)).OrderBy(_ => _Random.Next()).FirstOrDefault();
+                if (viableDestStation != null)
+                {
+                    var jobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random);
+                    if (jobChainController != null)
+                    {
+                        FinalizeJobChainControllerAndGenerateFirstJob(jobChainController);
+                    }
+                }
+                else
+                {
+                    Main._modEntry.Logger.Error($"Empty onsist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
+                    var (first, second) = SplitInHalf(trainCars);
+                    HandleEmptyPaxCars(first, station);
+                    HandleEmptyPaxCars(second, station);
+                    return;
+                }
+            }
+
+            Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+        }
+    }
+}

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -87,6 +87,7 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _ExtractPassengerJobData;
         private static MethodInfo _GetBookletTemplateData;
         private static MethodInfo _CreateLoadTaskPage;
+        private static MethodInfo _CreateCoupleTaskPage;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
@@ -161,6 +162,7 @@ namespace PersistentJobsMod.ModInteraction
                 _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
                 _GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
                 _CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
+                _CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
@@ -204,6 +206,8 @@ namespace PersistentJobsMod.ModInteraction
                 PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
 
                 PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
+
+                PatchPrefix(_CreateCoupleTaskPage, typeof(PaxJobsCompat), nameof(CreateCoupleTaskPage_Prefix));
 
             }
             catch (Exception e)
@@ -368,7 +372,7 @@ namespace PersistentJobsMod.ModInteraction
 
         //private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
         private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
-            
+
         private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
 
         private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
@@ -737,7 +741,7 @@ namespace PersistentJobsMod.ModInteraction
             if (!loaded)
             {
                 var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
-                newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { j, false });
+                _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
             }
 
             for (int i = 0; i < destinationTracks.Count - 1; i++)
@@ -981,6 +985,16 @@ namespace PersistentJobsMod.ModInteraction
                 }
             }
             return true;
+        }
+
+        private static bool CreateCoupleTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+        {
+            PassengerJobDataRef jobData = new(__args[0]);
+            var baseJobData = (TransportJobData)(jobData.Value);
+            var station = baseJobData.job.chainOriginStationInfo;
+            var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
+            __result = (TemplatePaperData)(CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) })).Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
+            return false;
         }
 
         private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -19,15 +19,10 @@ using static PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags;
 using Random = System.Random;
 
 #region RefType using
-using ConsistManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.ConsistManager>;
 using ExpressStationsChainDataRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.ExpressStationsChainData>;
 using IPassDestinationRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.IPassDestination>;
-using PassConsistInfoRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassConsistInfo>;
 using PassengerChainControllerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerChainController>;
 using PassengerHaulJobDefinitionRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerHaulJobDefinition>;
-using PassengerJobGeneratorRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerJobGenerator>;
-using PassJobTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassJobType>;
-using RouteManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteManager>;
 using RouteResultRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteResult>;
 using RouteTrackRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteTrack>;
 using RouteTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteType>;
@@ -91,6 +86,7 @@ namespace PersistentJobsMod.ModInteraction
 		private static MethodInfo _GetBookletTemplateData;
 		private static MethodInfo _CreateLoadTaskPage;
 		private static MethodInfo _CreateCoupleTaskPage;
+		private static MethodInfo _CreateCoupleTaskPaperData;
 		private static MethodInfo _LoadPassengerChain;
 
 		private static PropertyInfo _AllTracksProperty;
@@ -170,6 +166,7 @@ namespace PersistentJobsMod.ModInteraction
 				_GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
 				_CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
 				_CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
+				_CreateCoupleTaskPaperData = CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) });
 				_LoadPassengerChain = CompatAccess.Method(_JobSaveManagerPatch, "LoadPassengerChain", new[] { _PassengerChainSaveData });
 
 				_AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
@@ -205,7 +202,6 @@ namespace PersistentJobsMod.ModInteraction
 				//_AllPlatformControllers ??= UnityEngine.Object.FindObjectsOfType(_PlatformController) ?? throw new KeyNotFoundException("No platform controllesr present, this shouldn´t happen");
 
 				PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
-				PatchPostfix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Postfix));
 
 				PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
 
@@ -278,21 +274,12 @@ namespace PersistentJobsMod.ModInteraction
 			Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
 		}
 
-		//public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
 		private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
 		{
 			passengerChainController = null;
 			if (!AStartGameData.carsAndJobsLoadingFinished) return false;
 			if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
 			Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
-
-			/*if (!TryGetGenerator(yardId, out object generator))
-			{
-				Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
-				return false;
-			}
-
-			passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });*/
 
 			if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
 			{
@@ -330,13 +317,7 @@ namespace PersistentJobsMod.ModInteraction
 			return carLiveries != null && car.carLivery != null && carLiveries.Contains(car.carLivery);
 		}
 
-		public static float GetConsistLength(List<TrainCar> trainCars)
-		{
-			return CarSpawner.Instance.GetTotalCarsLength(
-				TrainCar.ExtractLogicCars(trainCars),
-				true
-			);
-		}
+		public static float GetConsistLength(List<TrainCar> trainCars) => CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true);
 
 		private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
 
@@ -383,7 +364,6 @@ namespace PersistentJobsMod.ModInteraction
 			return new(iPassDest);
 		}
 
-		//private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
 		private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
 
 		private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
@@ -469,7 +449,6 @@ namespace PersistentJobsMod.ModInteraction
 
 			Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
 
-			//if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(cars)), out JobChainController passangerChainController))
 			if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
 			{
 				Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
@@ -531,30 +510,6 @@ namespace PersistentJobsMod.ModInteraction
 			return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
 		}
 
-		private static void AddTransportTaskToTop(StaticJobDefinition staticPaxJobDefinition, Track currentTrack, Track destinatiionTrack, List<Car> cars)
-		{
-			if (staticPaxJobDefinition != null)
-			{
-				if (staticPaxJobDefinition.job == null)
-				{
-					Main._modEntry.Logger.Error("staticJobDefinition.job is null");
-					return;
-				}
-				var job = staticPaxJobDefinition.job;
-				Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
-				var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
-				if (headSequentialTask != null)
-				{
-					var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
-					newTransportTask.SetJobBelonging(job);
-					headSequentialTask.tasks.AddFirst(newTransportTask);
-				}
-				else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
-			}
-			else Main._modEntry.Logger.Error($"Couldn´t get job definition");
-
-		}
-
 		public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
 		{
 			List<JobChainController> result = new();
@@ -571,8 +526,6 @@ namespace PersistentJobsMod.ModInteraction
 			foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
 			{
 				Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
-				//handling complicated - no inbuilt methods for job generation from already loaded cars
-
 				HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
 				result.AddRange(jobChainControllers);
 			}
@@ -905,76 +858,12 @@ namespace PersistentJobsMod.ModInteraction
 				genCtx.OriginStation.AddJobToStation(genCtx.BaseJobDefinition.job);
 				return true;
 			}
-			catch(Exception ex) 
+			catch (Exception ex)
 			{
 				Main._modEntry.Logger.LogException("Failed to generate pax job due to: ", ex);
 				return false;
 			}
 		}
-
-		/*private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false, bool fromSave = false, bool taken = false)
-		{
-			// taken from PaxJobs - mostly original method code - in order to avoid using transpiler
-			float totalCapacity = 0;
-			foreach (var car in cars) totalCapacity += car.capacity;
-			var taskList = new List<Task>();
-			Track currentCarsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
-			Track initialTransportDestTrack = null;
-
-			if (!loaded)
-			{
-				var initialLoad = CreatePaxBoardingTask(startingRouteTrack, totalCapacity, true, false, __instance);
-				taskList.Add(initialLoad);
-			}
-			if (tracksMismatch) initialTransportDestTrack = GetRouteTrackTrackField(startingRouteTrack);
-			if (taken) initialTransportDestTrack = GetRouteTrackTrackField(GetFittingPlatformsForStation(StationController.GetStationByYardID(jobOriginStation.ID), TrainCar.ExtractTrainCars(cars)).GetRandomElement());
-			//there has to be some task based in the originating station to get couple page to exist
-			var initialTransportTask = CreatePaxTransportTask((fromSave ? initialTransportDestTrack : currentCarsTrack), initialTransportDestTrack ?? currentCarsTrack, __instance);
-			taskList.Insert(0, initialTransportTask);
-
-			List<string> destinationRouteTracksYardIDs = new();
-
-			for (int i = 0; i < destinationTracks.Count; i++)
-			{
-				bool isLast = (i == (destinationTracks.Count - 1));
-				var unloadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, false, isLast, __instance);
-				taskList.Add(unloadTask);
-
-				if (!isLast)
-				{
-					var loadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, true, false, __instance);
-					taskList.Add(loadTask);
-				}
-
-				destinationRouteTracksYardIDs.Add(GetRouteTrackTrackField(destinationTracks[i]).ID.yardId);
-			}
-
-			var chainData = (StationsChainData)CreateExpressStationsChainData(jobOriginStation.ID, destinationRouteTracksYardIDs.ToArray()).Value;
-			var superTask = new SequentialTasks(taskList);
-			var currentRouteType = _PHJD_RouteTypeField.GetValue(__instance);
-			var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
-			StaticJobDefinition baseJobDef = (StaticJobDefinition)__instance;
-			var newJob = new Job(superTask, jobType, timeLimit, initialWage, chainData, forcedJobId, requiredLicenses);
-			_StaticJobDefJobField.SetValue(__instance, newJob);
-
-			if (!loaded)
-			{
-				var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
-				_PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
-			}
-
-			for (int i = 0; i < destinationTracks.Count - 1; i++)
-			{
-				var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks[i])).Value;
-				newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
-			}
-
-			var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks.Last())).Value;
-			newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
-
-			jobOriginStation.AddJobToStation(baseJobDef.job);
-			return true;
-		}*/
 
 		private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
 		{
@@ -1077,9 +966,8 @@ namespace PersistentJobsMod.ModInteraction
 
 #pragma warning disable IDE0060 // Remove unused parameter
 
-		private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, out bool __state)
+		private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
 		{
-			__state = true;
 			var instanceBase = (StaticJobDefinition)__instance;
 			List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
 			RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
@@ -1102,65 +990,6 @@ namespace PersistentJobsMod.ModInteraction
 			PaxJobContext genCtx = new(__instance, chainSaveData, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, cars, startingRouteTrack, destinationTracks, taken, modified);
 
 			return !GeneratePaxJob(genCtx);
-		}
-
-			/*if (string.IsNullOrEmpty(forcedJobId)) ///generating new job case
-			{
-				if (loaded)
-				{
-					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: true);
-				}
-				if (GetRouteTrackTrackField(startingRouteTrack) != CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars))) //cars not at platform
-				{
-					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: false, tracksMismatch: true);
-				}
-
-				return true; //if cars are empty and on platform let PaxJobs generate job normally
-			}
-			else //loading job from save data case
-			{
-				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded is {(!modified ? "not " : "")}modified");
-				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded was {(!taken ? "not " : "")}taken");
-
-				if (modified)
-				{
-					__state = false;
-					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: loaded, fromSave: true, taken: taken);
-				}
-				return true;
-			}
-		}*/
-
-		private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, bool __state)
-		{
-			if (__state)
-			{
-				RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
-				List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
-				var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
-
-				if (GetRouteTrackTrackField(startingRouteTrack).ID.FullDisplayID != carsTrack.ID.FullDisplayID)
-				{
-					var jobs = jobOriginStation.availableJobs;
-					jobs.Reverse();
-
-					foreach (var job in jobs)
-					{
-						if (job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential) is not SequentialTasks sequential) continue;
-
-						if (sequential.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Transport) is not TransportTask transport) continue;
-
-						if ((bool)!transport.GetTaskData().cars.SequenceEqual(cars)) continue;
-
-						var startTrack = (Track)_TaskStartingTrackField.GetValue(transport);
-						if (startTrack == null || startTrack.ID.FullDisplayID == carsTrack.ID.FullDisplayID) continue;
-
-						_TaskStartingTrackField.SetValue(transport, carsTrack);
-						Main._modEntry.Logger.Log($"Changed start strack for job {job.ID}");
-						break;
-					}
-				}
-			}
 		}
 
 		private static void LoadPassengerChain_Postfix(object __result, object[] __args)
@@ -1276,7 +1105,7 @@ namespace PersistentJobsMod.ModInteraction
 			var baseJobData = (TransportJobData)(jobData.Value);
 			var station = baseJobData.job.chainOriginStationInfo;
 			var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
-			__result = (TemplatePaperData)(CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) })).Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
+			__result = (TemplatePaperData)_CreateCoupleTaskPaperData.Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
 			return false;
 		}
 

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -5,18 +5,36 @@ using HarmonyLib;
 using PersistentJobsMod.Extensions;
 using PersistentJobsMod.JobGenerators;
 using PersistentJobsMod.Utilities;
+using static PersistentJobsMod.Utilities.ReflectionUtilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
+using static PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags;
 using Random = System.Random;
+
+#region RefType using
+using ConsistManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.ConsistManager>;
+using ExpressStationsChainDataRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.ExpressStationsChainData>;
+using IPassDestinationRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.IPassDestination>;
+using PassConsistInfoRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassConsistInfo>;
+using PassengerChainControllerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerChainController>;
+using PassengerHaulJobDefinitionRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerHaulJobDefinition>;
+using PassengerJobGeneratorRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerJobGenerator>;
+using PassJobTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassJobType>;
+using RouteManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteManager>;
+using RouteResultRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteResult>;
+using RouteTrackRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteTrack>;
+using RouteTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteType>;
+#endregion
 
 namespace PersistentJobsMod.ModInteraction
 {
     public static class PaxJobsCompat
     {
+        #region Reflection setup
         private static Assembly asm;
 
         private static Type _RouteManager;
@@ -36,7 +54,6 @@ namespace PersistentJobsMod.ModInteraction
         private static ConstructorInfo _PassConsistInfoCtor;
         private static ConstructorInfo _PassengerJccCtor;
         private static ConstructorInfo _ExpressStChainDataCtor;
-
 
         private static MethodInfo _TryGetInstance;
         private static MethodInfo _GenerateJob;
@@ -71,7 +88,6 @@ namespace PersistentJobsMod.ModInteraction
 
         private static object _RouteTypeExpress;
         private static object _RouteTypeLocal;
-
         public static bool Initialize()
         {
             try
@@ -150,17 +166,24 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
-        internal static class CompatAccess
+        public class Tags
         {
-            public static Type Type(string fullName) => AccessTools.TypeByName(fullName) ?? throw new TypeLoadException($"Type not found: {fullName}");
-            public static MethodInfo Method(Type type, string name, Type[] args = null) => (args == null ? AccessTools.Method(type, name) : AccessTools.Method(type, name, args)) ?? throw new MissingMethodException(type.FullName, name);
-            public static ConstructorInfo Ctor(Type type, Type[] args) => AccessTools.Constructor(type, args) ?? throw new MissingMethodException(type.FullName, ".ctor");
-            public static PropertyInfo Property(Type type, string name) => AccessTools.Property(type, name) ?? throw new MissingMemberException(type.FullName, name);
-            public static FieldInfo Field(Type type, string name) => AccessTools.Field(type, name) ?? throw new MissingFieldException(type.FullName, name);
-            public static Type IEnumerableOf(Type elementType) => typeof(IEnumerable<>).MakeGenericType(elementType);
+            public sealed class RouteManager { };
+            public sealed class ConsistManager { };
+            public sealed class RouteTrack { };
+            public sealed class PassConsistInfo { };
+            public sealed class PassengerJobGenerator { };
+            public sealed class IPassDestination { };
+            public sealed class PassJobType { };
+            public sealed class PassengerChainController { };
+            public sealed class PassengerHaulJobDefinition { };
+            public sealed class RouteResult { };
+            public sealed class RouteType { };
+            public sealed class ExpressStationsChainData { };
         }
+        #endregion
 
-        private static bool TryGetGenerator(string yardId, out object generator)
+        /*private static bool TryGetGenerator(string yardId, out object generator)
         {
             generator = null;
             var args = new object[] { yardId, null };
@@ -172,10 +195,10 @@ namespace PersistentJobsMod.ModInteraction
 
             generator = args[1];
             return generator != null;
-        }
+        }*/
 
         //public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
-        public static bool TryGenerateJob(StationController station, JobType jobType, object startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
+        private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
         {
             passengerChainController = null;
             if (!AStartGameData.carsAndJobsLoadingFinished) return false;
@@ -200,13 +223,13 @@ namespace PersistentJobsMod.ModInteraction
             return passengerChainController != null;
         }
 
-        private static object CreateRouteTrack(object IPassDestination, Track terminalTrack) => _RouteTrackCtor.Invoke(new object[] { IPassDestination, terminalTrack });
+        private static RouteTrackRef CreateRouteTrack(IPassDestinationRef IPassDestination, Track terminalTrack) => new(_RouteTrackCtor.Invoke(new object[] { IPassDestination.Value, terminalTrack }));
 
-        private static object CreatePassConsistInfo(object routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack, cars });
+        private static object CreatePassConsistInfo(RouteTrackRef routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack.Value, cars });
 
-        private static object CreatePassJcc(GameObject jobChainGameObject) => _PassengerJccCtor.Invoke(new object[] { jobChainGameObject });
+        private static PassengerChainControllerRef CreatePassJcc(GameObject jobChainGameObject) => new(_PassengerJccCtor.Invoke(new object[] { jobChainGameObject }));
 
-        private static object CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => _ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds });
+        private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
 
         public static bool IsPaxCars(TrainCar car)
         {
@@ -226,58 +249,58 @@ namespace PersistentJobsMod.ModInteraction
 
         private static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
 
-        private static object GetStationData(string yardId) => _GetStationData.Invoke(null, new object[] { yardId }); // output is IPassDestination : PassStationData
+        private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
 
-        private static object GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => _GetRoute?.Invoke(null, new object[] { GetStationData(yardId), routeType, existingDests, minLength });
+        private static RouteResultRef GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => new(_GetRoute?.Invoke(null, new object[] { GetStationData(yardId).Value, routeType, existingDests, minLength }));
 
-        private static object GetRouteTrackByIdOrNull(string trackFullDisplayId)
+        private static RouteTrackRef GetRouteTrackByIdOrNull(string trackFullDisplayId)
         {
-            object routeTrackObj = _GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId });
-            if (routeTrackObj is null) return null;
-            Track trackField = GetRouteTrackTrackField(routeTrackObj);
-            if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return null;
-            return routeTrackObj;
+            RouteTrackRef routeTrack = new(_GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId }));
+            if (routeTrack.Value is null) return new(null);
+            Track trackField = GetRouteTrackTrackField(routeTrack);
+            if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return new(null);
+            return routeTrack;
         }
 
         private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
 
-        private static string YardIdFromPaxStation(object passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData);
+        private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
 
-        private static IEnumerable<object> GetPlatforms(object stationData, bool onlyTerminusTracks = false)
+        private static IEnumerable<RouteTrackRef> GetPlatforms(IPassDestinationRef stationData, bool onlyTerminusTracks = false)
         {
-            var result = _GetPlatforms.Invoke(stationData, new object[] { onlyTerminusTracks });
-            if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return item;
+            var result = _GetPlatforms.Invoke(stationData.Value, new object[] { onlyTerminusTracks });
+            if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return new(item);
         }
 
         private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
 
-        private static Track GetRouteTrackTrackField(object routeTrack)
+        private static Track GetRouteTrackTrackField(RouteTrackRef routeTrack)
         {
-            if (routeTrack == null) return null;
-            var track = (Track)_RouteTrackTrackField.GetValue(routeTrack);
+            if (routeTrack.Value == null) return null;
+            var track = (Track)_RouteTrackTrackField.GetValue(routeTrack.Value);
             if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
             return track;
         }
 
-        private static object GetRouteTrackStationField(object routeTrack)
+        private static IPassDestinationRef GetRouteTrackStationField(RouteTrackRef routeTrack)
         {
-            if (routeTrack == null) return null;
-            var iPassDest = _RouteTrackStationField.GetValue(routeTrack);
-            if (iPassDest == null) return null;
-            return iPassDest;
+            if (routeTrack.Value == null) return new(null);
+            var iPassDest = _RouteTrackStationField.GetValue(routeTrack.Value);
+            if (iPassDest == null) return new(null);
+            return new(iPassDest);
         }
 
-        private static double GetRouteTrackLength(object routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack);
+        private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
 
         private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
 
-        private static bool CanFitInStation(object stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
+        private static bool CanFitInStation(IPassDestinationRef stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
 
-        private static object GetRouteType(JobType type) => _GetRouteType.Invoke(null, new object[] { type });
+        private static RouteTypeRef GetRouteType(JobType type) => new(_GetRouteType.Invoke(null, new object[] { type }));
 
-        private static object GetRouteResultTracksArray(object routeResult) => _RouteResultTracksField.GetValue(routeResult);
+        private static object GetRouteResultTracksArray(RouteResultRef routeResult) => _RouteResultTracksField.GetValue(routeResult.Value);
 
-        private static float GetTotalHaulDistance(StationController startStation, object destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
+        private static float GetTotalHaulDistance(StationController startStation, Array destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
 
         private static JobType PickPassengerJobType(int carCount)
         {
@@ -287,11 +310,11 @@ namespace PersistentJobsMod.ModInteraction
             return _PassengerExpress;
         }
 
-        private static object PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, object startTrack, object routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => _PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack, routeResult, logicCars, chainData, timeLimit, initialPay });
+        private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
 
-        private static object SelectStartPlatformRouteTrack(Track currentTrack, List<object> fittingPlatforms)
+        private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
         {
-            if (!fittingPlatforms.Any()) return null;
+            if (!fittingPlatforms.Any()) return new(null);
 
             if (currentTrack != null)
             {
@@ -302,7 +325,7 @@ namespace PersistentJobsMod.ModInteraction
                     return track != null && track.ID.FullDisplayID == currentTrackId;
                 });
 
-                if (matchingPlatform != null)
+                if (matchingPlatform.Value != null)
                 {
                     Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
                     return matchingPlatform;
@@ -318,7 +341,7 @@ namespace PersistentJobsMod.ModInteraction
             }).FirstOrDefault();
         }
 
-        private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<object> fittingPlatforms, JobType jobType)
+        private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<RouteTrackRef> fittingPlatforms, JobType jobType)
         {
             List<JobChainController> result = new();
             if (trainCars.Count() > 20)
@@ -328,8 +351,8 @@ namespace PersistentJobsMod.ModInteraction
             }
 
             Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-            object preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
-            if (preferredRouteTrack == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
+            var preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
+            if (preferredRouteTrack.Value == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
             {
                 Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
                 result.AddRange(HandleSplitOrFail(trainCars, station));
@@ -344,7 +367,7 @@ namespace PersistentJobsMod.ModInteraction
 
             Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
 
-            //if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
+            //if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(cars)), out JobChainController passangerChainController))
             if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
@@ -371,7 +394,7 @@ namespace PersistentJobsMod.ModInteraction
                 foreach (var emptyTrainCars in emptyConsecutiveTrainCarGroups)
                 {
                     Main._modEntry.Logger.Log($"Spilitting consist starting with car {emptyTrainCars.First().ID}");
-                    var (first, second) = SplitInHalf((List<TrainCar>)emptyTrainCars);
+                    var (first, second) = emptyTrainCars.SplitInHalf();
                     HandleEmptyPaxCars(first, station, out List<JobChainController> outJobChainControllers);
                     result.AddRange(outJobChainControllers);
                     HandleEmptyPaxCars(second, station, out outJobChainControllers);
@@ -384,7 +407,7 @@ namespace PersistentJobsMod.ModInteraction
                 foreach (var loadedTrainCars in loadedConsecutiveTrainCarGroups)
                 {
                     Main._modEntry.Logger.Log($"Spilitting consist starting with car {loadedTrainCars.First().ID}");
-                    var (first, second) = SplitInHalf((List<TrainCar>)loadedTrainCars);
+                    var (first, second) = loadedTrainCars.SplitInHalf();
                     HandleLoadedPaxCars(first, station, out List<JobChainController> outJobChainControllers);
                     result.AddRange(outJobChainControllers);
                     HandleLoadedPaxCars(second, station, out outJobChainControllers);
@@ -455,22 +478,13 @@ namespace PersistentJobsMod.ModInteraction
             return result;
         }
 
-        public static (List<T> first, List<T> second) SplitInHalf<T>(IList<T> source)
-        {
-            if (source.Count() < 2) return (null, null);
-            int mid = (source.Count + 1) / 2;
-            var first = source.Take(mid).ToList();
-            var second = source.Skip(mid).ToList();
-            return (first, second);
-        }
-
         public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
         {
             trainCarGroups.RemoveAll(trainCars =>
             {
                 if (trainCars == null || trainCars.Count == 0)
                 {
-                    Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid trainCars input thrown out");
+                    Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid cars input thrown out");
                     return true;
                 }
                 if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
@@ -482,14 +496,14 @@ namespace PersistentJobsMod.ModInteraction
 
         private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
         {
-            var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID) == null ? new List<Track>() : (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList());
+            var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID).Value != null ? (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList()) : new List<Track>();
             return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
         }
 
-        private static List<object> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
+        private static List<RouteTrackRef> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
         {
             var stationData = GetStationData(station.stationInfo.YardID);
-            return stationData == null ? new List<object>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
+            return stationData.Value == null ? new List<RouteTrackRef>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
         }
 
         private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
@@ -513,7 +527,7 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
-        private static bool BuildAndGenerateJob(StationController startingStation, object startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
+        private static bool BuildAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
         {
             passengerChainController = null;
             //object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
@@ -521,22 +535,22 @@ namespace PersistentJobsMod.ModInteraction
                 .Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
                 .Select(j => j.chainData.chainDestinationYardId);
 
-            var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType), currentDests, GetConsistLength(trainCars));
-            if (destinations == null) return false;
+            var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType).Value, currentDests, GetConsistLength(trainCars));
+            if (destinations.Value == null) return false;
 
             var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
 
             if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
-            var destinationTracks = rrTracksArray.Cast<object>().Select(t => _RouteTrackTrackField.GetValue(t)).Cast<Track>().ToList();
-            var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(d)));
+            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new Foreign<RouteTrackRef>(o)).Select(rt => (Track)_RouteTrackTrackField.GetValue(rt.Value)).ToList();
+            var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(new RouteTrackRef(d))));
 
             // create job chain controller
             string destString = string.Join(" - ", destinationRouteTracksYardIDs);
             var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
             chainJobObject.transform.SetParent(startingStation.transform);
-            var chainController = (JobChainController)CreatePassJcc(chainJobObject);
+            var chainController = (JobChainController)CreatePassJcc(chainJobObject).Value;
 
-            var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray());
+            var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray()).Value;
             PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
 
             float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
@@ -545,7 +559,7 @@ namespace PersistentJobsMod.ModInteraction
 
             chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
 
-            var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment);
+            var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment).Value;
             if (jobDefinition == null)
             {
                 Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
@@ -662,9 +676,9 @@ namespace PersistentJobsMod.ModInteraction
         private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            object startingRouteTrack = _StartingTrackField.GetValue(__instance);
-            List<Car> trainCars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
-            var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(trainCars));
+            RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
+            List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+            var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
 
             if (GetRouteTrackTrackField(startingRouteTrack).ID.FullDisplayID != carsTrack.ID.FullDisplayID)
             {
@@ -677,7 +691,7 @@ namespace PersistentJobsMod.ModInteraction
 
                     if (sequential.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Transport) is not TransportTask transport) continue;
 
-                    if ((bool)!transport.GetTaskData().cars.SequenceEqual(trainCars)) continue;
+                    if ((bool)!transport.GetTaskData().cars.SequenceEqual(cars)) continue;
 
                     var startTrack = (Track)_TaskStartingTrackField.GetValue(transport);
                     if (startTrack == null || startTrack.ID.FullDisplayID == carsTrack.ID.FullDisplayID) continue;

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -28,6 +28,7 @@ using RouteManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<
 using RouteResultRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteResult>;
 using RouteTrackRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteTrack>;
 using RouteTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteType>;
+using PersistentJobsMod.Persistence;
 #endregion
 
 namespace PersistentJobsMod.ModInteraction
@@ -69,6 +70,8 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _GetJobPaymentData;
         private static MethodInfo _GetTotalHaulDistance;
         private static MethodInfo _PopulateExpressJobExistingCars;
+        private static MethodInfo _PaxJGeneratorStartGenerationAsync;
+        private static MethodInfo _PJGStartGenAsyncPrefix;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
@@ -80,6 +83,7 @@ namespace PersistentJobsMod.ModInteraction
         private static FieldInfo _TaskStartingTrackField;
         private static FieldInfo _RouteResultTracksField;
         private static FieldInfo _RouteTrackStationField;
+        private static FieldInfo _PaxJGeneratorStContField;
 
         private static Random _Random;
 
@@ -120,6 +124,7 @@ namespace PersistentJobsMod.ModInteraction
                 _GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
                 _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
                 _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
+                _PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
@@ -131,6 +136,7 @@ namespace PersistentJobsMod.ModInteraction
                 _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
                 _RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
                 _RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
+                _PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -154,6 +160,18 @@ namespace PersistentJobsMod.ModInteraction
                 else
                 {
                     Main._modEntry.Logger.Error("Failed to find methods required to patch PassengerHaulJobDefinition.GenerateJob");
+                    throw new MethodAccessException();
+                }
+
+                _PJGStartGenAsyncPrefix = typeof(PaxJobsCompat).GetMethod(nameof(StartGenerationAsync_Prefix), BindingFlags.Static | BindingFlags.NonPublic);
+                if (_PaxJGeneratorStartGenerationAsync != null && _PJGStartGenAsyncPrefix != null)
+                {
+                    Main.Harmony.Patch(_PaxJGeneratorStartGenerationAsync, prefix: new HarmonyMethod(_PJGStartGenAsyncPrefix));
+                    Main._modEntry.Logger.Log("Successfully patched PassengerJobGenerator.StartGenerationAsync");
+                }
+                else
+                {
+                    Main._modEntry.Logger.Error("Failed to find methods required to patch PassengerJobGenerator.StartGenerationAsync");
                     throw new MethodAccessException();
                 }
             }
@@ -182,8 +200,10 @@ namespace PersistentJobsMod.ModInteraction
             public sealed class ExpressStationsChainData { };
         }
         #endregion
+        
+        public static bool OverrideSpawnFlagForPaxJ = false;
 
-        /*private static bool TryGetGenerator(string yardId, out object generator)
+        private static bool TryGetGenerator(string yardId, out object generator)
         {
             generator = null;
             var args = new object[] { yardId, null };
@@ -195,7 +215,18 @@ namespace PersistentJobsMod.ModInteraction
 
             generator = args[1];
             return generator != null;
-        }*/
+        }
+
+        public static void PaxJobsOrigGenJobsInStation(string yardId)
+        {
+            if (!TryGetGenerator(yardId, out object generator))
+            {
+                Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
+                return;
+            }
+            _PaxJGeneratorStartGenerationAsync.Invoke(generator, new object[0]);
+            Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
+        }
 
         //public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
         private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
@@ -247,7 +278,7 @@ namespace PersistentJobsMod.ModInteraction
 
         private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
 
-        private static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
+        public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
 
         private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
 
@@ -672,6 +703,7 @@ namespace PersistentJobsMod.ModInteraction
             Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
         }
 
+        #region PaxJobs Patches
 #pragma warning disable IDE0060 // Remove unused parameter
         private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
 #pragma warning restore IDE0060 // Remove unused parameter
@@ -702,5 +734,22 @@ namespace PersistentJobsMod.ModInteraction
                 }
             }
         }
+
+        private static bool StartGenerationAsync_Prefix(object __instance)
+        {
+            StationController generatingStation = (StationController)_PaxJGeneratorStContField.GetValue(__instance);
+            if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(generatingStation) && !OverrideSpawnFlagForPaxJ)
+            {
+                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} has already spawned cars, skipping passanger jobs with new cars generation");
+                return false;
+            }
+            else
+            {
+                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} is generating passanger jobs with cars");
+                OverrideSpawnFlagForPaxJ = false;
+                return true;
+            }
+        }
+        #endregion
     }
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -295,6 +295,18 @@ namespace PersistentJobsMod.ModInteraction
 
         private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
 
+        public static bool IsPaxJobDefinition(StaticJobDefinition jobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)
+        {
+            passengerHaulJobDefinition = new(null);
+            if (jobDefinition == null) return false;
+            var job = jobDefinition.job;
+            if (job == null) return false;
+            bool correctType = (job.jobType == _PassengerExpress || job.jobType == _PassengerLocal);
+            bool correctDef = _PassengerHaulJobDefinition.IsInstanceOfType(jobDefinition);
+            passengerHaulJobDefinition = new(jobDefinition);
+            return correctType && correctDef;
+        }
+
         public static bool IsPaxCars(TrainCar car)
         {
             var carLiveries = (IEnumerable<TrainCarLivery>)_GetPassengerCars.Invoke(null, null);
@@ -356,7 +368,7 @@ namespace PersistentJobsMod.ModInteraction
 
         //private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
         private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
-
+            
         private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
 
         private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
@@ -722,8 +734,11 @@ namespace PersistentJobsMod.ModInteraction
             var newJob = new Job(superTask, jobType, timeLimit, initialWage, chainData, forcedJobId, requiredLicenses);
             _StaticJobDefJobField.SetValue(__instance, newJob);
 
-            var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
-            newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { j, false });
+            if (!loaded)
+            {
+                var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
+                newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { j, false });
+            }
 
             for (int i = 0; i < destinationTracks.Count - 1; i++)
             {

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -26,6 +26,8 @@ namespace PersistentJobsMod.ModInteraction
         private static Type _PassengerJobGenerator;
         private static Type _IPassDestination;
         private static Type _PassJobType;
+        private static Type _PassengerChainController;
+        private static Type _PassengerHaulJobDefinition;
 
         private static ConstructorInfo _RouteTrackCtor;
         private static ConstructorInfo _PassConsistInfoCtor;
@@ -39,8 +41,10 @@ namespace PersistentJobsMod.ModInteraction
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
+        private static PropertyInfo _TrainCarsToTransportProp;
 
         private static FieldInfo _RouteTrackTrackField;
+        private static FieldInfo _StartingTrackField;
 
         private static Random _Random;
 
@@ -60,6 +64,8 @@ namespace PersistentJobsMod.ModInteraction
                 _PassengerJobGenerator = CompatAccess.Type("PassengerJobs.Generation.PassengerJobGenerator");
                 _IPassDestination = CompatAccess.Type("PassengerJobs.Generation.IPassDestination");
                 _PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
+                _PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
+                _PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
 
                 _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
                 _GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
@@ -71,8 +77,10 @@ namespace PersistentJobsMod.ModInteraction
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
+                _TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
 
                 _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
+                _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -159,6 +167,8 @@ namespace PersistentJobsMod.ModInteraction
 
         private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
 
+        private static List<Car> GetTrainCarsForPaxJobDefinition(StaticJobDefinition staticPaxJobDefinition) => (List<Car>)_TrainCarsToTransportProp.GetValue(staticPaxJobDefinition);
+
         private static IEnumerable<object> GetPlatforms(object stationData, bool onlyTerminusTracks = false)
         {
             var result = _GetPlatforms.Invoke(stationData, new object[] { onlyTerminusTracks });
@@ -166,6 +176,8 @@ namespace PersistentJobsMod.ModInteraction
         }
 
         private static Track GetRouteTractTrackField(object routeTrack) => (Track)_RouteTrackTrackField.GetValue(routeTrack);
+
+        private static object GetPaxHaulJobDefStartingRouteTrackField(StaticJobDefinition staticPaxJobDefinition) => _StartingTrackField.GetValue(staticPaxJobDefinition);
 
         private static double GetRouteTrackLength(object routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack);
 
@@ -270,6 +282,31 @@ namespace PersistentJobsMod.ModInteraction
             Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
             Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
             return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
+        }
+
+        private static void AddTransportTaskToTop(JobChainController paxJobChainController)
+        {
+            if (_PassengerChainController.IsInstanceOfType(paxJobChainController))
+            {
+                var staticPaxJobDefinition = paxJobChainController.jobChain.FirstOrDefault();
+                if (staticPaxJobDefinition != null)
+                {
+                    var job = staticPaxJobDefinition.job;
+                    var cars = paxJobChainController.carsForJobChain;
+                    Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
+                    var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
+                    if (headSequentialTask != null)
+                    {
+                        var newTransportTask = JobsGenerator.CreateTransportTask(cars, GetRouteTractTrackField(GetPaxHaulJobDefStartingRouteTrackField(staticPaxJobDefinition)), CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars)));
+                        var newParallelHoldingTask = new ParallelTasks(new List<Task> { newTransportTask });
+                        newParallelHoldingTask.SetJobBelonging(job);
+                        headSequentialTask.tasks.AddFirst(newParallelHoldingTask);
+                    }
+                    else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
+                }
+                else Main._modEntry.Logger.Error($"Couldn´t get job definition");
+            }
+
         }
 
         public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
@@ -423,7 +460,14 @@ namespace PersistentJobsMod.ModInteraction
 
                 JobType jobType = PickPassengerJobType(trainCars.Count);
                 if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes 
-                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
+
+                List<JobChainController> processedControllers = new();
+                foreach (var jcc in TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType))
+                {
+                    AddTransportTaskToTop(jcc);
+                    processedControllers.Add(jcc);
+                }
+                jobChainControllers.AddRange(processedControllers);
                 return;
             }
             else

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -28,7 +28,9 @@ using RouteManagerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<
 using RouteResultRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteResult>;
 using RouteTrackRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteTrack>;
 using RouteTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteType>;
+using PlatformControllerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PlatformController>;
 using PersistentJobsMod.Persistence;
+using DV.Booklets;
 #endregion
 
 namespace PersistentJobsMod.ModInteraction
@@ -50,6 +52,8 @@ namespace PersistentJobsMod.ModInteraction
         private static Type _RouteResult;
         private static Type _RouteType;
         private static Type _ExpressStationsChainData;
+        private static Type _PlatformController;
+        private static Type _BookletUtility;
 
         private static ConstructorInfo _RouteTrackCtor;
         private static ConstructorInfo _PassConsistInfoCtor;
@@ -64,26 +68,34 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _GetRouteTrackById;
         private static MethodInfo _GetPlatforms;
         private static MethodInfo _PHJD_GenerateJob;
-        private static MethodInfo _PHJD_GenJobPostfix;
         private static MethodInfo _GetRoute;
         private static MethodInfo _GetRouteType;
         private static MethodInfo _GetJobPaymentData;
         private static MethodInfo _GetTotalHaulDistance;
         private static MethodInfo _PopulateExpressJobExistingCars;
         private static MethodInfo _PaxJGeneratorStartGenerationAsync;
-        private static MethodInfo _PJGStartGenAsyncPrefix;
+        private static MethodInfo _PHJD_CreateBoardingTask;
+        private static MethodInfo _PHJD_CreateTransportTask;
+        private static MethodInfo _PlatformControllerForTrack;
+        private static MethodInfo _PlatformRegisterOutgoingJob;
+        private static MethodInfo _PlatformRegisterIncomingJob;
+        private static MethodInfo _ExtractPassengerJobData;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
         private static PropertyInfo _TrainCarsToTransportProp;
         private static PropertyInfo _PaxStYardIdProperty;
+        private static PropertyInfo _RTPlatformIdProp;
 
         private static FieldInfo _RouteTrackTrackField;
         private static FieldInfo _StartingTrackField;
+        private static FieldInfo _DestinationTracksField;
         private static FieldInfo _TaskStartingTrackField;
         private static FieldInfo _RouteResultTracksField;
         private static FieldInfo _RouteTrackStationField;
         private static FieldInfo _PaxJGeneratorStContField;
+        private static FieldInfo _PHJD_RouteTypeField;
+        private static FieldInfo _StaticJobDefJobField;
 
         private static Random _Random;
 
@@ -92,6 +104,9 @@ namespace PersistentJobsMod.ModInteraction
 
         private static object _RouteTypeExpress;
         private static object _RouteTypeLocal;
+
+        //private static UnityEngine.Object[] _AllPlatformControllers;
+
         public static bool Initialize()
         {
             try
@@ -110,6 +125,9 @@ namespace PersistentJobsMod.ModInteraction
                 _RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
                 _RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
                 _ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
+                _PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
+                _BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
+                _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData");
 
                 _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
                 _GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
@@ -125,18 +143,27 @@ namespace PersistentJobsMod.ModInteraction
                 _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
                 _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
                 _PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
+                _PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack , typeof(float), typeof(bool), typeof(bool) } );
+                _PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track)});
+                _PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] {typeof(string)});
+                _PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool)} );
+                _PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool)} );
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
                 _TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
                 _PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
+                _RTPlatformIdProp = CompatAccess.Property(_RouteTrack, "PlatformID");
 
                 _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
                 _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
+                _DestinationTracksField = CompatAccess.Field(_PassengerHaulJobDefinition, "DestinationTracks");
                 _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
                 _RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
                 _RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
                 _PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
+                _PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
+                _StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -151,29 +178,15 @@ namespace PersistentJobsMod.ModInteraction
                 _RouteTypeExpress = Enum.Parse(_RouteType, "Express");
                 _RouteTypeLocal = Enum.Parse(_RouteType, "Local");
 
-                _PHJD_GenJobPostfix = typeof(PaxJobsCompat).GetMethod(nameof(GenerateJob_Postfix), BindingFlags.Static | BindingFlags.NonPublic);
-                if (_PHJD_GenerateJob != null && _PHJD_GenJobPostfix != null)
-                {
-                    Main.Harmony.Patch(_PHJD_GenerateJob, postfix: new HarmonyMethod(_PHJD_GenJobPostfix));
-                    Main._modEntry.Logger.Log("Successfully patched PassengerHaulJobDefinition.GenerateJob");
-                }
-                else
-                {
-                    Main._modEntry.Logger.Error("Failed to find methods required to patch PassengerHaulJobDefinition.GenerateJob");
-                    throw new MethodAccessException();
-                }
+                //_AllPlatformControllers ??= UnityEngine.Object.FindObjectsOfType(_PlatformController) ?? throw new KeyNotFoundException("No platform controllesr present, this shouldn´t happen");
 
-                _PJGStartGenAsyncPrefix = typeof(PaxJobsCompat).GetMethod(nameof(StartGenerationAsync_Prefix), BindingFlags.Static | BindingFlags.NonPublic);
-                if (_PaxJGeneratorStartGenerationAsync != null && _PJGStartGenAsyncPrefix != null)
-                {
-                    Main.Harmony.Patch(_PaxJGeneratorStartGenerationAsync, prefix: new HarmonyMethod(_PJGStartGenAsyncPrefix));
-                    Main._modEntry.Logger.Log("Successfully patched PassengerJobGenerator.StartGenerationAsync");
-                }
-                else
-                {
-                    Main._modEntry.Logger.Error("Failed to find methods required to patch PassengerJobGenerator.StartGenerationAsync");
-                    throw new MethodAccessException();
-                }
+                PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
+                PatchPostfix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Postfix));
+
+                PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
+
+                PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
+
             }
             catch (Exception e)
             {
@@ -198,6 +211,7 @@ namespace PersistentJobsMod.ModInteraction
             public sealed class RouteResult { };
             public sealed class RouteType { };
             public sealed class ExpressStationsChainData { };
+            public sealed class PlatformController { };
         }
         #endregion
         
@@ -244,7 +258,7 @@ namespace PersistentJobsMod.ModInteraction
 
             passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });*/
 
-            if (!BuildAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
+            if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
             {
                 Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
                 return false;
@@ -293,7 +307,7 @@ namespace PersistentJobsMod.ModInteraction
             return routeTrack;
         }
 
-        private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
+        private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId).Value)).ToList();
 
         private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
 
@@ -321,6 +335,11 @@ namespace PersistentJobsMod.ModInteraction
             return new(iPassDest);
         }
 
+        //private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
+        private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
+
+        private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
+
         private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
 
         private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
@@ -342,6 +361,10 @@ namespace PersistentJobsMod.ModInteraction
         }
 
         private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
+
+        private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] {platform.Value, totalCapacity, loading, isFinal}));
+
+        private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack});
 
         private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
         {
@@ -558,7 +581,7 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
-        private static bool BuildAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
+        private static bool SetupAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
         {
             passengerChainController = null;
             //object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
@@ -607,6 +630,67 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
+        private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false)
+        {
+            // taken from PaxJobs - mostly original method code - in order to avoid using transpiler
+            float totalCapacity = 0;
+            foreach (var car in cars) totalCapacity += car.capacity;
+            var taskList = new List<Task>();
+            Track currentCarsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
+            Track initialTransportDestTrack = null;
+
+            if (!loaded) 
+            {
+                var initialLoad = CreatePaxBoardingTask(startingRouteTrack, totalCapacity, true, false, __instance);
+                taskList.Add(initialLoad);
+            }
+            if (tracksMismatch) initialTransportDestTrack = GetRouteTrackTrackField(startingRouteTrack);
+
+            //there has to be some task based in the originating station to get couple page to exist
+            var initialTransportTask = CreatePaxTransportTask(currentCarsTrack, initialTransportDestTrack ?? currentCarsTrack, __instance);
+            taskList.Insert(0, initialTransportTask);
+
+            List<string> destinationRouteTracksYardIDs = new();
+
+            for (int i = 0; i < destinationTracks.Count; i++)
+            {
+                bool isLast = (i == (destinationTracks.Count - 1));
+                var unloadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, false, isLast, __instance);
+                taskList.Add(unloadTask);
+
+                if (!isLast)
+                {
+                    var loadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, true, false, __instance);
+                    taskList.Add(loadTask);
+                }
+
+                destinationRouteTracksYardIDs.Add(GetRouteTrackTrackField(destinationTracks[i]).ID.yardId);
+            }
+
+            var chainData = (StationsChainData)CreateExpressStationsChainData(jobOriginStation.ID, destinationRouteTracksYardIDs.ToArray()).Value;
+            var superTask = new SequentialTasks(taskList);
+            var currentRouteType = _PHJD_RouteTypeField.GetValue(__instance);
+            var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
+            StaticJobDefinition baseJobDef = (StaticJobDefinition)__instance;
+            var newJob = new Job(superTask, jobType, timeLimit, initialWage, chainData, forcedJobId, requiredLicenses);
+            _StaticJobDefJobField.SetValue(__instance, newJob);
+
+            var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
+            newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { j, false });
+
+            for (int i = 0; i < destinationTracks.Count - 1; i++)
+            {
+                var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks[i])).Value;
+                newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
+            }
+
+            var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks.Last())).Value;
+            newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
+            
+            jobOriginStation.AddJobToStation(baseJobDef.job);
+            return true;
+        }
+
         private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
         {
             jobChainControllers = new();
@@ -646,7 +730,7 @@ namespace PersistentJobsMod.ModInteraction
                 }
                 else
                 {
-                    Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
+                    Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a FH to any pax station, attempting splitting");
                     jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
                     return;
                 }
@@ -703,8 +787,37 @@ namespace PersistentJobsMod.ModInteraction
             Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
         }
 
+
         #region PaxJobs Patches
+
 #pragma warning disable IDE0060 // Remove unused parameter
+
+        private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
+        {
+            List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+            RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
+            if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
+
+            if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
+            {
+                Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
+                return false;
+            }
+
+            if (cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None))
+            {
+                return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: true);
+            }
+
+            if (GetRouteTrackTrackField(startingRouteTrack) != CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars)))
+            {
+                return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: false, tracksMismatch: true);
+            }
+
+            return true;
+        }
+
         private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
@@ -750,6 +863,48 @@ namespace PersistentJobsMod.ModInteraction
                 return true;
             }
         }
+
+        private static bool ExtractPassengerJobData_Prefix(ref Job_data job)
+        {
+            //adding a dummy load task data if there is none in origin station
+
+            if (job.tasksData == null || job.tasksData.Length == 0) return false;
+
+            var taskSequence = job.tasksData[0];
+            if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1) return false;
+
+            var firstNestedTask = taskSequence.nestedTasks[0];
+            if (firstNestedTask.instanceTaskType != TaskType.Transport) return true;
+
+            Task_data[] newNestedTasks = null;
+            bool loadingFound = false;
+            foreach (var taskData in taskSequence.nestedTasks)
+            {
+                if (taskData.instanceTaskType != TaskType.Warehouse) continue;
+                if (taskData.warehouseTaskType == WarehouseTaskType.Loading)
+                {
+                    loadingFound = true;
+                    continue;
+                }
+                if (taskData.warehouseTaskType == WarehouseTaskType.Unloading && !loadingFound)
+                {
+                    //var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(CarTrackAssignment.TrainCarsByGuid(taskData.cars.Select(c => c.ID)));
+                    var carsTrack = firstNestedTask.startTrackID;
+                    if (carsTrack == null) break;
+
+                    var destTrack = GetRouteTrackTrackField(GetPlatforms(GetStationData(carsTrack.yardId)).First());
+                    var taskList = taskSequence.nestedTasks.ToList();
+                    taskList.Insert(1, new Task_data(TaskType.Warehouse, TaskType.Warehouse, TaskState.InProgress, 0, 0, taskData.cars, carsTrack, destTrack.ID, WarehouseTaskType.None, new List<CargoType>(), 0, false, false, Array.Empty<Task_data>()));
+                    newNestedTasks = taskList.ToArray();
+                    break;
+                }
+            }
+
+            if (newNestedTasks?.Length > 1) taskSequence.nestedTasks = newNestedTasks;
+            job.tasksData[0] = taskSequence;
+            return true;
+        }
+
         #endregion
     }
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -163,7 +163,7 @@ namespace PersistentJobsMod.ModInteraction
                 _PassengerChainSaveData = CompatAccess.Type("PassengerJobs.Generation.PassengerChainSaveData");
                 _PJMain = CompatAccess.Type("PassengerJobs.PJMain");
                 _PJModSettings = CompatAccess.Type("PassengerJobs.PJModSettings");
-                _PJExtensions = CompatAccess.Type("PassengerJobs.Extensions");
+                _PJExtensions = CompatAccess.Type("PassengerJobs.Extensions.Extensions");
                 _CityLoadingTask = CompatAccess.Type("PassengerJobs.Platforms.CityLoadingTask");
                 _RuralLoadingTask = CompatAccess.Type("PassengerJobs.Platforms.RuralLoadingTask");
 

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -38,6 +38,8 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _GetStationData;
         private static MethodInfo _GetRouteTrackById;
         private static MethodInfo _GetPlatforms;
+        private static MethodInfo _PHJD_GenerateJob;
+        private static MethodInfo _PHJD_GenJobPostfix;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
@@ -45,6 +47,7 @@ namespace PersistentJobsMod.ModInteraction
 
         private static FieldInfo _RouteTrackTrackField;
         private static FieldInfo _StartingTrackField;
+        private static FieldInfo _TaskStartingTrackField;
 
         private static Random _Random;
 
@@ -74,6 +77,7 @@ namespace PersistentJobsMod.ModInteraction
                 _GetStationData = CompatAccess.Method(_RouteManager, "GetStationData");
                 _GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
                 _GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
+                _PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
@@ -81,6 +85,7 @@ namespace PersistentJobsMod.ModInteraction
 
                 _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
                 _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
+                _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -89,12 +94,25 @@ namespace PersistentJobsMod.ModInteraction
 
                 _PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
                 _PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
+
+                _PHJD_GenJobPostfix = typeof(PaxJobsCompat).GetMethod(nameof(GenerateJob_Postfix), BindingFlags.Static | BindingFlags.NonPublic);
+                if (_PHJD_GenerateJob != null && _PHJD_GenJobPostfix != null)
+                {
+                    Main.Harmony.Patch(_PHJD_GenerateJob, postfix: new HarmonyMethod(_PHJD_GenJobPostfix));
+                    Main._modEntry.Logger.Log("Successfully patched PassengerHaulJobDefinition.GenerateJob");
+                }
+                else
+                {
+                    Main._modEntry.Logger.Error("Failed to find methods required to patch PassengerHaulJobDefinition.GenerateJob");
+                    throw new MethodAccessException();
+                }
             }
             catch (Exception e)
             {
                 Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods", e);
                 return false;
             }
+
             return true;
         }
 
@@ -180,6 +198,8 @@ namespace PersistentJobsMod.ModInteraction
             var result = _GetPlatforms.Invoke(stationData, new object[] { onlyTerminusTracks });
             if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return item;
         }
+
+        private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
 
         private static Track GetRouteTrackTrackField(object routeTrack)
         {
@@ -369,14 +389,10 @@ namespace PersistentJobsMod.ModInteraction
             return trainCarGroups;
         }
 
-        private static Track GetRandomFittingPlatform(StationController targetStation, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
+        private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
         {
-            var fittingPlatforms = GetFittingPlatformsForStation(targetStation, trainCars, onlyTerminusTracks);
-
-            if (!fittingPlatforms.Any()) return null;
-
-            var randomRouteTrack = fittingPlatforms.GetRandomElement();
-            return GetRouteTrackTrackField(randomRouteTrack);
+            var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID) == null ? new List<Track>() : (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList());
+            return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
         }
 
         private static List<object> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
@@ -429,11 +445,11 @@ namespace PersistentJobsMod.ModInteraction
             else
             {
                 Main._modEntry.Logger.Log($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get unloaded");
-                //generate FH job to random pax station: use already existing mod logic elswhere -- potentially chnge to use SP tracks which PaxJobs currently doesn´t - wait for update?
+                //generate FH job to random pax station: use already existing mod logic elswhere
                 StationController viableDestStation = FindDestinationStation(station, trainCars);
                 if (viableDestStation != null)
                 {
-                    Track possibleDestinationTrack = GetRandomFittingPlatform(viableDestStation, trainCars, true);
+                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
                     JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
                     if (transportJobChainController != null)
                     {
@@ -470,18 +486,18 @@ namespace PersistentJobsMod.ModInteraction
                 }
 
                 JobType jobType = PickPassengerJobType(trainCars.Count);
-                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes 
+                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes <-- do this dynamically from PaxJobs routes list?
                 jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
                 return;
             }
             else
             {
                 Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned a pax job");
-                //generate LH job to random pax station: use already existing mod logic elswhere -- potentially chnge to use SP tracks which PaxJobs currently doesn´t - wait for update?
+                //generate LH job to random pax station: use already existing mod logic elswhere
                 StationController viableDestStation = FindDestinationStation(station, trainCars);
                 if (viableDestStation != null)
                 {
-                    Track possibleDestinationTrack = GetRandomFittingPlatform(viableDestStation, trainCars);
+                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
                     JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
                     if (emptyHaulJobChainController != null)
                     {
@@ -499,6 +515,37 @@ namespace PersistentJobsMod.ModInteraction
             }
 
             Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+        }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+        private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            object startingRouteTrack = _StartingTrackField.GetValue(__instance);
+            List<Car> trainCars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+            var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(trainCars));
+
+            if (GetRouteTrackTrackField(startingRouteTrack).ID.FullDisplayID != carsTrack.ID.FullDisplayID)
+            {
+                var jobs = jobOriginStation.availableJobs;
+                jobs.Reverse();
+
+                foreach (var job in jobs)
+                {
+                    if (job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential) is not SequentialTasks sequential) continue;
+
+                    if (sequential.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Transport) is not TransportTask transport) continue;
+
+                    if ((bool)!transport.GetTaskData().cars.SequenceEqual(trainCars)) continue;
+
+                    var startTrack = (Track)_TaskStartingTrackField.GetValue(transport);
+                    if (startTrack == null || startTrack.ID.FullDisplayID == carsTrack.ID.FullDisplayID) continue;
+
+                    _TaskStartingTrackField.SetValue(transport, carsTrack);
+                    Main._modEntry.Logger.Log($"Changed start strack for job {job.ID}");
+                    break;
+                }
+            }
         }
     }
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -1,16 +1,19 @@
 ﻿using DV;
+using DV.Booklets;
 using DV.Logic.Job;
 using DV.ThingTypes;
+using DV.RenderTextureSystem.BookletRender;
 using HarmonyLib;
 using PersistentJobsMod.Extensions;
 using PersistentJobsMod.JobGenerators;
 using PersistentJobsMod.Utilities;
-using static PersistentJobsMod.Utilities.ReflectionUtilities;
+using PersistentJobsMod.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using static PersistentJobsMod.Utilities.ReflectionUtilities;
 using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
 using static PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags;
 using Random = System.Random;
@@ -29,8 +32,7 @@ using RouteResultRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<P
 using RouteTrackRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteTrack>;
 using RouteTypeRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.RouteType>;
 using PlatformControllerRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PlatformController>;
-using PersistentJobsMod.Persistence;
-using DV.Booklets;
+using PassengerJobDataRef = PersistentJobsMod.Utilities.ReflectionUtilities.Foreign<PersistentJobsMod.ModInteraction.PaxJobsCompat.Tags.PassengerJobData>;
 #endregion
 
 namespace PersistentJobsMod.ModInteraction
@@ -54,6 +56,9 @@ namespace PersistentJobsMod.ModInteraction
         private static Type _ExpressStationsChainData;
         private static Type _PlatformController;
         private static Type _BookletUtility;
+        private static Type _BookletCreator_JobPatch;
+        private static Type _PassengerJobData;
+        private static Type _PassStopInfo;
 
         private static ConstructorInfo _RouteTrackCtor;
         private static ConstructorInfo _PassConsistInfoCtor;
@@ -80,6 +85,8 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _PlatformRegisterOutgoingJob;
         private static MethodInfo _PlatformRegisterIncomingJob;
         private static MethodInfo _ExtractPassengerJobData;
+        private static MethodInfo _GetBookletTemplateData;
+        private static MethodInfo _CreateLoadTaskPage;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
@@ -96,6 +103,7 @@ namespace PersistentJobsMod.ModInteraction
         private static FieldInfo _PaxJGeneratorStContField;
         private static FieldInfo _PHJD_RouteTypeField;
         private static FieldInfo _StaticJobDefJobField;
+        private static FieldInfo _InitialStopField;
 
         private static Random _Random;
 
@@ -127,7 +135,9 @@ namespace PersistentJobsMod.ModInteraction
                 _ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
                 _PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
                 _BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
-                _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData");
+                _BookletCreator_JobPatch = CompatAccess.Type("PassengerJobs.Patches.BookletCreator_JobPatch");
+                _PassengerJobData = CompatAccess.Type("PassengerJobs.PassengerJobData");
+                _PassStopInfo = CompatAccess.Type("PassengerJobs.PassStopInfo");
 
                 _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
                 _GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
@@ -143,11 +153,14 @@ namespace PersistentJobsMod.ModInteraction
                 _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
                 _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
                 _PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
-                _PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack , typeof(float), typeof(bool), typeof(bool) } );
-                _PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track)});
-                _PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] {typeof(string)});
-                _PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool)} );
-                _PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool)} );
+                _PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack, typeof(float), typeof(bool), typeof(bool) });
+                _PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track) });
+                _PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] { typeof(string) });
+                _PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool) });
+                _PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool) });
+                _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
+                _GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
+                _CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
@@ -164,6 +177,7 @@ namespace PersistentJobsMod.ModInteraction
                 _PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
                 _PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
                 _StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
+                _InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -186,6 +200,10 @@ namespace PersistentJobsMod.ModInteraction
                 PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
 
                 PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
+
+                PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
+
+                PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
 
             }
             catch (Exception e)
@@ -212,9 +230,10 @@ namespace PersistentJobsMod.ModInteraction
             public sealed class RouteType { };
             public sealed class ExpressStationsChainData { };
             public sealed class PlatformController { };
+            public sealed class PassengerJobData { };
         }
         #endregion
-        
+
         public static bool OverrideSpawnFlagForPaxJ = false;
 
         private static bool TryGetGenerator(string yardId, out object generator)
@@ -362,9 +381,9 @@ namespace PersistentJobsMod.ModInteraction
 
         private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
 
-        private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] {platform.Value, totalCapacity, loading, isFinal}));
+        private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] { platform.Value, totalCapacity, loading, isFinal }));
 
-        private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack});
+        private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack });
 
         private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
         {
@@ -564,6 +583,35 @@ namespace PersistentJobsMod.ModInteraction
 
         private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
 
+        private static bool FilterJobDataForModPaxJob(ref Job_data job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit)
+        {
+            firstNestedTask = null;
+            taskSequence = null;
+
+            if (job.tasksData == null || job.tasksData.Length == 0)
+            {
+                exit = true;
+                return false;
+            }
+
+            taskSequence = job.tasksData[0];
+            if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1)
+            {
+                exit = true;
+                return false;
+            }
+
+            firstNestedTask = taskSequence.nestedTasks[0];
+            if (firstNestedTask.instanceTaskType != TaskType.Transport)
+            {
+                exit = true;
+                return true;
+            }
+
+            exit = false;
+            return false;
+        }
+
         private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
         {
             startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
@@ -639,13 +687,12 @@ namespace PersistentJobsMod.ModInteraction
             Track currentCarsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
             Track initialTransportDestTrack = null;
 
-            if (!loaded) 
+            if (!loaded)
             {
                 var initialLoad = CreatePaxBoardingTask(startingRouteTrack, totalCapacity, true, false, __instance);
                 taskList.Add(initialLoad);
             }
             if (tracksMismatch) initialTransportDestTrack = GetRouteTrackTrackField(startingRouteTrack);
-
             //there has to be some task based in the originating station to get couple page to exist
             var initialTransportTask = CreatePaxTransportTask(currentCarsTrack, initialTransportDestTrack ?? currentCarsTrack, __instance);
             taskList.Insert(0, initialTransportTask);
@@ -686,7 +733,7 @@ namespace PersistentJobsMod.ModInteraction
 
             var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks.Last())).Value;
             newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
-            
+
             jobOriginStation.AddJobToStation(baseJobDef.job);
             return true;
         }
@@ -819,7 +866,6 @@ namespace PersistentJobsMod.ModInteraction
         }
 
         private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
-#pragma warning restore IDE0060 // Remove unused parameter
         {
             RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
             List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
@@ -868,13 +914,8 @@ namespace PersistentJobsMod.ModInteraction
         {
             //adding a dummy load task data if there is none in origin station
 
-            if (job.tasksData == null || job.tasksData.Length == 0) return false;
-
-            var taskSequence = job.tasksData[0];
-            if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1) return false;
-
-            var firstNestedTask = taskSequence.nestedTasks[0];
-            if (firstNestedTask.instanceTaskType != TaskType.Transport) return true;
+            bool result = FilterJobDataForModPaxJob(ref job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit);
+            if (exit) return result;
 
             Task_data[] newNestedTasks = null;
             bool loadingFound = false;
@@ -905,6 +946,34 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
+        private static bool CreateLoadTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+        {
+            //skip creation of load page for our modified jobs (starting with transport) that are from loaded cars
+
+            PassengerJobDataRef jobData = new(__args[0]);
+            object initialStopInfo = __args[1];
+            if (_InitialStopField.GetValue(jobData.Value) == initialStopInfo)
+            {
+                var baseJobData = ((TransportJobData)jobData.Value).job;
+                bool result = FilterJobDataForModPaxJob(ref baseJobData, out _, out Task_data firstNestedTask, out bool exit);
+                if (exit) return result;
+
+                if (firstNestedTask.startTrackID == firstNestedTask.destinationTrackID)
+                {
+                    //from context we now know (hopefully?) that the cars were loaded 
+                    __result = null;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)
+        {
+            __result = __result.Where(t => t != null).ToList();
+        }
+
+#pragma warning restore IDE0060 // Remove unused parameter
         #endregion
     }
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -98,7 +98,6 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
-
         internal static class CompatAccess
         {
             public static Type Type(string fullName) => AccessTools.TypeByName(fullName) ?? throw new TypeLoadException($"Type not found: {fullName}");
@@ -167,7 +166,7 @@ namespace PersistentJobsMod.ModInteraction
         {
             object routeTrackObj = _GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId });
             if (routeTrackObj is null) return null;
-            Track trackField = GetRouteTractTrackField(routeTrackObj);
+            Track trackField = GetRouteTrackTrackField(routeTrackObj);
             if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return null;
             return routeTrackObj;
         }
@@ -182,7 +181,7 @@ namespace PersistentJobsMod.ModInteraction
             if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return item;
         }
 
-        private static Track GetRouteTractTrackField(object routeTrack)
+        private static Track GetRouteTrackTrackField(object routeTrack)
         {
             if (routeTrack == null) return null;
             var track = (Track)_RouteTrackTrackField.GetValue(routeTrack);
@@ -213,7 +212,7 @@ namespace PersistentJobsMod.ModInteraction
                 string currentTrackId = currentTrack.ID.FullDisplayID;
                 var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
                 {
-                    var track = GetRouteTractTrackField(rt);
+                    var track = GetRouteTrackTrackField(rt);
                     return track != null && track.ID.FullDisplayID == currentTrackId;
                 });
 
@@ -222,21 +221,29 @@ namespace PersistentJobsMod.ModInteraction
                     Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
                     return matchingPlatform;
                 }
-                Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random platform");
+                Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random free platform");
             }
-            else Main._modEntry.Logger.Log("Could not determine current track, selecting random platform");
+            else Main._modEntry.Logger.Log("Could not determine current track, selecting random free platform");
 
-            return RandomExtensions.GetRandomElement(_Random, fittingPlatforms);
+            return fittingPlatforms.OrderByDescending(p =>
+            {
+                var track = GetRouteTrackTrackField(p) ?? new Track(0);
+                return track.length - track.OccupiedLength;
+            }).FirstOrDefault();
         }
 
         private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<object> fittingPlatforms, JobType jobType)
         {
             List<JobChainController> result = new();
-            if (trainCars.Count() > 20) result.AddRange(HandleSplitOrFail(trainCars, station));
+            if (trainCars.Count() > 20)
+            {
+                result.AddRange(HandleSplitOrFail(trainCars, station));
+                return result;
+            }
 
             Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
             object preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
-            if (preferredRouteTrack == null || GetRouteTractTrackField(preferredRouteTrack).ID == null)
+            if (preferredRouteTrack == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
             {
                 Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
                 result.AddRange(HandleSplitOrFail(trainCars, station));
@@ -249,18 +256,11 @@ namespace PersistentJobsMod.ModInteraction
                 return result;
             }
 
-            Main._modEntry.Logger.Log($"Picked platform {GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID} ");
+            Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
 
             if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
-                
-                /*if (GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID != currentTrack.ID.FullDisplayID && passangerChainController != null)
-                {
-                    AddTransportTaskToTop(passangerChainController, currentTrack, GetRouteTractTrackField(preferredRouteTrack));
-                }
-                else { passangerChainController.FinalizeSetupAndGenerateFirstJob(); }*/
-
                 result.Add(passangerChainController);
                 return result;
             }
@@ -317,41 +317,6 @@ namespace PersistentJobsMod.ModInteraction
             Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
             Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
             return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
-        }
-
-        private static void AddTransportTaskToTop(JobChainController paxJobChainController, Track currentTrack, Track destinatiionTrack)
-        {
-            if (_PassengerChainController.IsInstanceOfType(paxJobChainController))
-            {
-                if (!paxJobChainController.jobChain.Any())
-                {
-                    Main._modEntry.Logger.Error("jcc jobChain field is null or empty");
-                    return;
-                }
-                paxJobChainController.FinalizeSetupAndGenerateFirstJob();
-                var staticPaxJobDefinition = paxJobChainController.jobChain.FirstOrDefault();
-                if (staticPaxJobDefinition != null)
-                {
-                    if (staticPaxJobDefinition.job == null)
-                    {
-                        Main._modEntry.Logger.Error("staticJobDefinition.job is null");
-                        return;
-                    }
-                    var job = staticPaxJobDefinition.job;
-                    var cars = paxJobChainController.carsForJobChain;
-                    Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
-                    var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
-                    if (headSequentialTask != null)
-                    {
-                        var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
-                        var newParallelHoldingTask = new ParallelTasks(new List<Task> { newTransportTask });
-                        newParallelHoldingTask.SetJobBelonging(job);
-                        headSequentialTask.tasks.AddFirst(newParallelHoldingTask);
-                    }
-                    else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
-                }
-                else Main._modEntry.Logger.Error($"Couldn´t get job definition");
-            }
         }
 
         public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
@@ -411,7 +376,7 @@ namespace PersistentJobsMod.ModInteraction
             if (!fittingPlatforms.Any()) return null;
 
             var randomRouteTrack = fittingPlatforms.GetRandomElement();
-            return GetRouteTractTrackField(randomRouteTrack);
+            return GetRouteTrackTrackField(randomRouteTrack);
         }
 
         private static List<object> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -236,17 +236,31 @@ namespace PersistentJobsMod.ModInteraction
 
             Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
             object preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
-            if (preferredRouteTrack == null)
+            if (preferredRouteTrack == null || GetRouteTractTrackField(preferredRouteTrack).ID == null)
             {
                 Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
                 result.AddRange(HandleSplitOrFail(trainCars, station));
                 return result;
             }
 
+            if (!fittingPlatforms.Contains(preferredRouteTrack))
+            {
+                Main._modEntry.Logger.Error("Selected RouteTrack is not in fitting platforms list");
+                return result;
+            }
+
+            Main._modEntry.Logger.Log($"Picked platform {GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID} ");
+
             if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
-                if (GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID != currentTrack.ID.FullDisplayID) AddTransportTaskToTop(passangerChainController, currentTrack, GetRouteTractTrackField(preferredRouteTrack));
+                
+                /*if (GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID != currentTrack.ID.FullDisplayID && passangerChainController != null)
+                {
+                    AddTransportTaskToTop(passangerChainController, currentTrack, GetRouteTractTrackField(preferredRouteTrack));
+                }
+                else { passangerChainController.FinalizeSetupAndGenerateFirstJob(); }*/
+
                 result.Add(passangerChainController);
                 return result;
             }
@@ -309,9 +323,20 @@ namespace PersistentJobsMod.ModInteraction
         {
             if (_PassengerChainController.IsInstanceOfType(paxJobChainController))
             {
+                if (!paxJobChainController.jobChain.Any())
+                {
+                    Main._modEntry.Logger.Error("jcc jobChain field is null or empty");
+                    return;
+                }
+                paxJobChainController.FinalizeSetupAndGenerateFirstJob();
                 var staticPaxJobDefinition = paxJobChainController.jobChain.FirstOrDefault();
                 if (staticPaxJobDefinition != null)
                 {
+                    if (staticPaxJobDefinition.job == null)
+                    {
+                        Main._modEntry.Logger.Error("staticJobDefinition.job is null");
+                        return;
+                    }
                     var job = staticPaxJobDefinition.job;
                     var cars = paxJobChainController.carsForJobChain;
                     Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
@@ -327,7 +352,6 @@ namespace PersistentJobsMod.ModInteraction
                 }
                 else Main._modEntry.Logger.Error($"Couldn´t get job definition");
             }
-
         }
 
         public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
@@ -352,7 +376,7 @@ namespace PersistentJobsMod.ModInteraction
                 result.AddRange(jobChainControllers);
             }
 
-            foreach (var jcc in result) FinalizeJobChainControllerAndGenerateFirstJob(jcc);
+            //foreach (var jcc in result) if (_PassengerChainController.IsInstanceOfType(jcc)) FinalizeJobChainControllerAndGenerateFirstJob(jcc);
             return result;
         }
 
@@ -448,6 +472,7 @@ namespace PersistentJobsMod.ModInteraction
                     JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
                     if (transportJobChainController != null)
                     {
+                        transportJobChainController.FinalizeSetupAndGenerateFirstJob();
                         jobChainControllers.Add(transportJobChainController);
                         return;
                     }
@@ -495,6 +520,7 @@ namespace PersistentJobsMod.ModInteraction
                     JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
                     if (emptyHaulJobChainController != null)
                     {
+                        emptyHaulJobChainController.FinalizeSetupAndGenerateFirstJob();
                         jobChainControllers.Add(emptyHaulJobChainController);
                         return;
                     }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -246,8 +246,8 @@ namespace PersistentJobsMod.ModInteraction
 			public sealed class PlatformController { };
 			public sealed class PassengerJobData { };
 
-			public class PaxJobModifiedFlag : MonoBehaviour { }
-			public class PaxJobJobTakenFlag : MonoBehaviour { }
+			public class PaxJobModifiedFlag : MonoBehaviour { };
+			public class PaxJobJobTakenFlag : MonoBehaviour { public JobChainSaveData jobChainSaveData; };
 		}
 		#endregion
 
@@ -707,19 +707,212 @@ namespace PersistentJobsMod.ModInteraction
 			return true;
 		}
 
-        enum PaxJobGenerationMode
-        {
-            Vanilla,                    
-            Empty_OnPlatform,
-            Empty_OffPlatform,
-            Loaded,
-            Loaded_Taken_FromSave,
-            Empty_Taken_FromSave
-        }
+		internal readonly struct PaxJobContext
+		{
+#nullable enable
+			public readonly object JobDefinitionInstance;
+			public readonly StaticJobDefinition BaseJobDefinition;
+			public readonly JobChainSaveData? JobChainSaveData;
 
+			public readonly string ForcedJobId;
+			public readonly bool FromSave;
+			public readonly bool JobTaken;
 
+			public readonly Station OriginStation;
+			public readonly float TimeLimit;
+			public readonly float InitialWage;
+			public readonly JobLicenses RequiredLicenses;
 
-        private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false, bool fromSave = false, bool taken = false)
+			public readonly IReadOnlyList<Car> Cars;
+			public readonly float TotalCapacity;
+			public readonly bool CarsLoaded;
+
+			public readonly RouteTrackRef StartingRouteTrack;
+			public readonly Track StartingTrack;
+			public readonly Track CarsCurrentTrack;
+
+			public readonly IReadOnlyList<RouteTrackRef> DestinationRouteTracks;
+			public readonly IReadOnlyList<Track> DestinationTracks;
+
+			public readonly bool WasModifiedAtSave;
+
+			public PaxJobContext(object jobDefinitionInstance, JobChainSaveData jobChainSaveData, Station originStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, IReadOnlyList<Car> cars, RouteTrackRef startingRouteTrack, IReadOnlyList<RouteTrackRef> destinationRouteTracks, bool jobTaken, bool wasModifiedAtSave)
+			{
+				JobDefinitionInstance = jobDefinitionInstance;
+				BaseJobDefinition = (StaticJobDefinition)jobDefinitionInstance;
+				JobChainSaveData = jobChainSaveData;
+
+				OriginStation = originStation;
+				TimeLimit = timeLimit;
+				InitialWage = initialWage;
+				ForcedJobId = forcedJobId;
+				FromSave = !string.IsNullOrEmpty(forcedJobId);
+				JobTaken = jobTaken;
+				WasModifiedAtSave = wasModifiedAtSave;
+				RequiredLicenses = requiredLicenses;
+
+				Cars = cars;
+				CarsLoaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
+				TotalCapacity = cars.Sum(c => c.capacity);
+
+				StartingRouteTrack = startingRouteTrack;
+				StartingTrack = GetRouteTrackTrackField(startingRouteTrack);
+				CarsCurrentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars((List<Car>)cars));
+
+				DestinationRouteTracks = destinationRouteTracks;
+				DestinationTracks = destinationRouteTracks.Select(rt => GetRouteTrackTrackField(rt)).ToArray();
+			}
+#nullable disable
+		}
+
+		internal enum PaxJobGenerationMode
+		{
+			None,
+			Empty_OnPlatform,
+			Empty_OffPlatform,
+			Loaded,
+			Loaded_Taken_From_Empty,
+			Loaded_Taken_From_Loaded,
+			Empty_Taken
+		}
+
+		private static PaxJobGenerationMode GetPaxJobGenerationMode(PaxJobContext genCtx)
+		{
+			if (!genCtx.JobTaken)
+			{
+				if (genCtx.CarsLoaded) return PaxJobGenerationMode.Loaded;
+				if (genCtx.CarsCurrentTrack == genCtx.StartingTrack) return PaxJobGenerationMode.Empty_OnPlatform;
+				else return PaxJobGenerationMode.Empty_OffPlatform;
+			}
+			else
+			{
+				if (genCtx.CarsLoaded)
+				{
+					var chainSaveData = genCtx.JobChainSaveData;
+					if (!(chainSaveData == null || chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0))
+					{
+						var headTask = chainSaveData.currentJobTaskData[0];
+						if ((headTask.type == TaskType.Sequential) && (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0))
+						{
+							//there are two warehouse tasks for each intermediate stations + the initial load + final unload
+							int numWarehouseTasks = complexData.tasksData.Count(tsd => tsd.type == TaskType.Warehouse);
+							if ((numWarehouseTasks % 2) == 0) return PaxJobGenerationMode.Loaded_Taken_From_Empty;
+							else return PaxJobGenerationMode.Loaded_Taken_From_Loaded;
+						}
+					}
+				}
+				else
+				{
+					return PaxJobGenerationMode.Empty_Taken;
+				}
+			}
+
+			return PaxJobGenerationMode.None;
+		}
+
+		private static void DestinationsTasks(ref List<Task> taskList, PaxJobContext genCtx)
+		{
+			var destinationTracks = genCtx.DestinationRouteTracks;
+			for (int i = 0; i < destinationTracks.Count; i++)
+			{
+				bool isLast = (i == (destinationTracks.Count - 1));
+				var unloadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, false, isLast, genCtx.JobDefinitionInstance);
+				taskList.Add(unloadTask);
+
+				if (!isLast)
+				{
+					var loadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance);
+					taskList.Add(loadTask);
+				}
+			}
+		}
+
+		private static SequentialTasks BuildUpTasks(PaxJobContext genCtx, PaxJobGenerationMode mode)
+		{
+			var taskList = new List<Task>();
+
+			switch (mode)
+			{
+				case PaxJobGenerationMode.Empty_OnPlatform:
+					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				case PaxJobGenerationMode.Empty_OffPlatform:
+					taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				case PaxJobGenerationMode.Loaded:
+					taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.CarsCurrentTrack, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				case PaxJobGenerationMode.Loaded_Taken_From_Empty:
+					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				case PaxJobGenerationMode.Loaded_Taken_From_Loaded:
+					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				case PaxJobGenerationMode.Empty_Taken:
+					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+					DestinationsTasks(ref taskList, genCtx);
+					break;
+
+				default:
+					throw new InvalidOperationException("Task list could not be built!");
+			}
+
+			return new(taskList);
+		}
+
+		private static bool GeneratePaxJob(PaxJobContext genCtx)
+		{
+			try
+			{
+				var genMode = GetPaxJobGenerationMode(genCtx);
+				var chainData = (StationsChainData)CreateExpressStationsChainData(genCtx.OriginStation.ID, genCtx.DestinationRouteTracks.Select(rt => (GetRouteTrackTrackField(rt)).ID.yardId).ToArray()).Value;
+				var superTask = BuildUpTasks(genCtx, genMode);
+				var currentRouteType = _PHJD_RouteTypeField.GetValue(genCtx.JobDefinitionInstance);
+				var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
+				var newJob = new Job(superTask, jobType, genCtx.TimeLimit, genCtx.InitialWage, chainData, genCtx.ForcedJobId, genCtx.RequiredLicenses);
+				_StaticJobDefJobField.SetValue(genCtx.JobDefinitionInstance, newJob);
+
+				if (genCtx.FromSave) Main._modEntry.Logger.Log($"Loading job {genCtx.ForcedJobId} from save with gen mode {genMode}");
+
+				if (genMode == PaxJobGenerationMode.Empty_OnPlatform || genMode == PaxJobGenerationMode.Empty_OffPlatform || genMode == PaxJobGenerationMode.Empty_Taken)
+				{
+					var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.StartingRouteTrack)).Value;
+					_PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
+				}
+
+				for (int i = 0; i < genCtx.DestinationRouteTracks.Count - 1; i++)
+				{
+					var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks[i])).Value;
+					newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
+				}
+
+				var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks.Last())).Value;
+				newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
+
+				genCtx.OriginStation.AddJobToStation(genCtx.BaseJobDefinition.job);
+				return true;
+			}
+			catch(Exception ex) 
+			{
+				Main._modEntry.Logger.LogException("Failed to generate pax job due to: ", ex);
+				return false;
+			}
+		}
+
+		/*private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false, bool fromSave = false, bool taken = false)
 		{
 			// taken from PaxJobs - mostly original method code - in order to avoid using transpiler
 			float totalCapacity = 0;
@@ -781,7 +974,7 @@ namespace PersistentJobsMod.ModInteraction
 
 			jobOriginStation.AddJobToStation(baseJobDef.job);
 			return true;
-		}
+		}*/
 
 		private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
 		{
@@ -893,14 +1086,25 @@ namespace PersistentJobsMod.ModInteraction
 			if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
 			var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
 
+			var definitionGO = ((MonoBehaviour)__instance).gameObject;
+			bool modified = definitionGO.GetComponent<PaxJobModifiedFlag>() != null;
+			var takenFlag = definitionGO.GetComponent<PaxJobJobTakenFlag>();
+			JobChainSaveData chainSaveData = takenFlag?.jobChainSaveData;
+			bool taken = takenFlag != null;
+
 			if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
 			{
 				Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
 				return false;
 			}
-
 			bool loaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
-			if (string.IsNullOrEmpty(forcedJobId)) /*generating new job case*/
+
+			PaxJobContext genCtx = new(__instance, chainSaveData, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, cars, startingRouteTrack, destinationTracks, taken, modified);
+
+			return !GeneratePaxJob(genCtx);
+		}
+
+			/*if (string.IsNullOrEmpty(forcedJobId)) ///generating new job case
 			{
 				if (loaded)
 				{
@@ -913,24 +1117,8 @@ namespace PersistentJobsMod.ModInteraction
 
 				return true; //if cars are empty and on platform let PaxJobs generate job normally
 			}
-			else /*loading job from save data case*/
+			else //loading job from save data case
 			{
-				//var jobDefComponent = (MonoBehaviour)__instance;
-				//var currentJcc = jobDefComponent.GetComponent<JobChainController>();
-				//var chainsInStation = StationController.GetStationByYardID(jobOriginStation.ID).ProceduralJobsController.GetCurrentJobChains();
-				//var currentJcc = chainsInStation.FirstOrDefault(jcc => jcc.carsForJobChain.MultisetEquals(cars) && jcc.jobChain.Any(sjd => (string)CompatAccess.Field(sjd.GetType(), "forcedJobId").GetValue(sjd) == forcedJobId));
-
-				/*if (currentJcc == null)
-				{
-					Main._modEntry.Logger.Error($"JCC not found on GameObject for job {forcedJobId}");
-					//return true;
-				}*/
-				//bool modified = currentJcc.jobChainGO.GetComponent<PaxJobModifiedFlag>() != null;
-				
-				var definitionGO = ((MonoBehaviour)__instance).gameObject;
-				bool modified = definitionGO.GetComponent<PaxJobModifiedFlag>() != null;
-				bool taken = definitionGO.GetComponent<PaxJobJobTakenFlag>() != null;
-
 				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded is {(!modified ? "not " : "")}modified");
 				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded was {(!taken ? "not " : "")}taken");
 
@@ -941,7 +1129,7 @@ namespace PersistentJobsMod.ModInteraction
 				}
 				return true;
 			}
-		}
+		}*/
 
 		private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, bool __state)
 		{
@@ -988,9 +1176,10 @@ namespace PersistentJobsMod.ModInteraction
 				if (chainSaveData.jobTaken)
 				{
 					Main._modEntry.Logger.Log($"Adding 'JobTaken' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
-					jcc.jobChainGO.AddComponent<PaxJobJobTakenFlag>();
+					var flag = jcc.jobChainGO.AddComponent<PaxJobJobTakenFlag>();
+					flag.jobChainSaveData = chainSaveData;
 				}
-				
+
 
 				var headTask = chainSaveData.currentJobTaskData[0];
 				if (headTask.type != TaskType.Sequential) return;

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnityEngine;
 using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
 using Random = System.Random;
 
@@ -154,7 +155,7 @@ namespace PersistentJobsMod.ModInteraction
 
         private static object GetStationData(string yardId) => _GetStationData?.Invoke(null, new object[] { yardId }); // output is IPassDestination : PassStationData
 
-        private static object GetRouteTrackById(string trackId) => _GetRouteTrackById?.Invoke(null, new object[] { trackId });
+        private static object GetRouteTrackById(string trackFullDisplayId) => _GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId });
 
         private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
 
@@ -168,13 +169,7 @@ namespace PersistentJobsMod.ModInteraction
 
         private static double GetRouteTrackLength(object routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack);
 
-        private static bool CanFitInStation(object stationData, List<TrainCar> trainCars)
-        {
-            float consistLength = GetConsistLength(trainCars);
-
-            return GetPlatforms(stationData)
-                .Any(rt => consistLength <= GetRouteTrackLength(rt));
-        }
+        private static bool CanFitInStation(object stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
 
         private static JobType PickPassengerJobType(int carCount)
         {
@@ -187,13 +182,40 @@ namespace PersistentJobsMod.ModInteraction
         private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<object> fittingPlatforms, JobType jobType)
         {
             List<JobChainController> result = new();
-            var routeTrack = RandomExtensions.GetRandomElement(_Random, fittingPlatforms);
-            var consistInfo = CreatePassConsistInfo(routeTrack, TrainCar.ExtractLogicCars(trainCars));
+
+            if (trainCars.Count() > 20) result.AddRange(HandleSplitOrFail(trainCars, station));
+
+            object preferredRouteTrack = null;
+            var currentTrackLogic = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+            if (currentTrackLogic != null)
+            {
+                var currentRouteTrackObject = GetRouteTrackById(currentTrackLogic.ID.FullDisplayID);
+                if (currentRouteTrackObject != null)
+                {
+                    Main._modEntry.Logger.Log($"Current track for consist starting with {trainCars.First().ID} is {GetRouteTractTrackField(currentRouteTrackObject)}");
+
+                    string currentTrackId = GetRouteTractTrackField(currentRouteTrackObject).ID.FullDisplayID;
+                    if (fittingPlatforms.Any(rt => GetRouteTractTrackField(rt).ID.FullDisplayID == currentTrackId)) preferredRouteTrack = currentRouteTrackObject;
+                }
+                else Main._modEntry.Logger.Log($"Didn´t find PaxJobs RouteTrack for current track {currentTrackLogic.ID.FullID}");
+            }
+            else Main._modEntry.Logger.Log($"Couldn´t get current track for consist starting with {trainCars.First().ID}");
+
+            preferredRouteTrack ??= RandomExtensions.GetRandomElement(_Random, fittingPlatforms);
+            if (preferredRouteTrack == null)
+            {
+                Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID} to generate a job.");
+                result.AddRange(HandleSplitOrFail(trainCars, station));
+                return result;
+            }
+
+            var consistInfo = CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars));
 
             if (TryGenerateJob(station.stationInfo.YardID, jobType, consistInfo, out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
                 result.Add(passangerChainController);
+                return result;
             }
 
             result.AddRange(HandleSplitOrFail(trainCars, station));
@@ -271,6 +293,8 @@ namespace PersistentJobsMod.ModInteraction
                 HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
                 result.AddRange(jobChainControllers);
             }
+
+            foreach (var jcc in result) FinalizeJobChainControllerAndGenerateFirstJob(jcc);
             return result;
         }
 
@@ -298,9 +322,9 @@ namespace PersistentJobsMod.ModInteraction
             return trainCarGroups;
         }
 
-        private static Track GetRandomFittingPlatform(StationController targetStation, List<TrainCar> trainCars)
+        private static Track GetRandomFittingPlatform(StationController targetStation, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
         {
-            var fittingPlatforms = GetFittingPlatformsForStation(targetStation, trainCars);
+            var fittingPlatforms = GetFittingPlatformsForStation(targetStation, trainCars, onlyTerminusTracks);
 
             if (!fittingPlatforms.Any()) return null;
 
@@ -308,13 +332,15 @@ namespace PersistentJobsMod.ModInteraction
             return GetRouteTractTrackField(randomRouteTrack);
         }
 
-        private static List<object> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars)
+        private static List<object> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
         {
             var stationData = GetStationData(station.stationInfo.YardID);
-            return stationData == null ? new List<object>() : (GetPlatforms(stationData).Where(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
+            return stationData == null ? new List<object>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
         }
 
-        private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(_ => _Random.Next()).FirstOrDefault();
+        private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
+
+        private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
 
         private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
         {
@@ -360,11 +386,10 @@ namespace PersistentJobsMod.ModInteraction
                 StationController viableDestStation = FindDestinationStation(station, trainCars);
                 if (viableDestStation != null)
                 {
-                    Track possibleDestinationTrack = GetRandomFittingPlatform(viableDestStation, trainCars);
+                    Track possibleDestinationTrack = GetRandomFittingPlatform(viableDestStation, trainCars, true);
                     JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
                     if (transportJobChainController != null)
                     {
-                        FinalizeJobChainControllerAndGenerateFirstJob(transportJobChainController);
                         jobChainControllers.Add(transportJobChainController);
                         return;
                     }
@@ -377,7 +402,7 @@ namespace PersistentJobsMod.ModInteraction
                 }
             }
 
-            Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+            Main._modEntry.Logger.Error("[HandleLoadedPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
         }
 
         private static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
@@ -397,6 +422,7 @@ namespace PersistentJobsMod.ModInteraction
                 }
 
                 JobType jobType = PickPassengerJobType(trainCars.Count);
+                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes 
                 jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
                 return;
             }
@@ -411,7 +437,6 @@ namespace PersistentJobsMod.ModInteraction
                     JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
                     if (emptyHaulJobChainController != null)
                     {
-                        FinalizeJobChainControllerAndGenerateFirstJob(emptyHaulJobChainController);
                         jobChainControllers.Add(emptyHaulJobChainController);
                         return;
                     }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -4,7 +4,6 @@ using DV.Logic.Job;
 using DV.ThingTypes;
 using DV.RenderTextureSystem.BookletRender;
 using HarmonyLib;
-using MessageBox;
 using PersistentJobsMod.Extensions;
 using PersistentJobsMod.JobGenerators;
 using PersistentJobsMod.Utilities;
@@ -14,7 +13,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using UnityEngine;
 using static PersistentJobsMod.Utilities.ReflectionUtilities;
 using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
@@ -122,6 +120,7 @@ namespace PersistentJobsMod.ModInteraction
         private static FieldInfo _InitialStopField;
         private static FieldInfo _BaseWageScale;
         private static FieldInfo _CustomWagesField;
+        private static FieldInfo _BonusTimeScale;
 
         private static Random _Random;
 
@@ -219,6 +218,7 @@ namespace PersistentJobsMod.ModInteraction
                 _InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
                 _BaseWageScale = CompatAccess.Field(_PassengerJobGenerator, "BASE_WAGE_SCALE");
                 _CustomWagesField = CompatAccess.Field(_PJModSettings, "UseCustomWages");
+                _BonusTimeScale = CompatAccess.Field(_PJModSettings, "TimeScale");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
@@ -266,20 +266,7 @@ namespace PersistentJobsMod.ModInteraction
             {
                 Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods, trying to unpatch", e);
 
-                StringBuilder s = new();
-                foreach (var (target, patchContainer, patchMethodName) in ReflectionUtilities.patchRecord)
-                {
-                    try
-                    {
-                        Main.Harmony.Unpatch(target, HarmonyPatchType.All, Main.Harmony.Id);
-                    }
-                    catch (Exception ex)
-                    {
-                        Main._modEntry.Logger.LogException($"Error when unpatching {target.Name}!", ex);
-                        s.AppendLine(target.Name + ": " + ex.Message);
-                    }
-                }
-                if (s.Length > 0) PopupAPI.ShowOk("State is not clean, there might be problems. \n" + s);
+                UnpatchAll();
 
                 return false;
             }
@@ -721,13 +708,13 @@ namespace PersistentJobsMod.ModInteraction
             PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
 
             float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
-            float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false) * GetTimeMultiplier(jobType);
+            float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false) * GetTimeMultiplier(jobType) * ((float)_BonusTimeScale.GetValue(_PJMainSettingsProp.GetValue(null) ?? 1));
             bonusLimit += GetTimeForStops(destinations);
             float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
             float? wageScale = 1;
             if (TryGetGenerator(startingStation.logicStation.ID, out object generator))
             {
-                wageScale = (float)((bool)_CustomWagesField?.GetValue(_PJMainSettingsProp.GetValue(null)) ? _BaseWageScale?.GetValue(generator) : 1);
+                wageScale = (float)((bool)_CustomWagesField.GetValue(_PJMainSettingsProp.GetValue(null)) ? _BaseWageScale.GetValue(generator) : 1);
             }
             transportPayment = Mathf.Round((float)(transportPayment * wageScale));
 

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -28,9 +28,16 @@ namespace PersistentJobsMod.ModInteraction
         private static Type _PassJobType;
         private static Type _PassengerChainController;
         private static Type _PassengerHaulJobDefinition;
+        private static Type _RouteResult;
+        private static Type _RouteType;
+        private static Type _ExpressStationsChainData;
 
         private static ConstructorInfo _RouteTrackCtor;
         private static ConstructorInfo _PassConsistInfoCtor;
+        private static ConstructorInfo _PassengerJccCtor;
+        private static ConstructorInfo _ExpressStChainDataCtor;
+
+
         private static MethodInfo _TryGetInstance;
         private static MethodInfo _GenerateJob;
         private static MethodInfo _GetPassengerCars;
@@ -40,19 +47,30 @@ namespace PersistentJobsMod.ModInteraction
         private static MethodInfo _GetPlatforms;
         private static MethodInfo _PHJD_GenerateJob;
         private static MethodInfo _PHJD_GenJobPostfix;
+        private static MethodInfo _GetRoute;
+        private static MethodInfo _GetRouteType;
+        private static MethodInfo _GetJobPaymentData;
+        private static MethodInfo _GetTotalHaulDistance;
+        private static MethodInfo _PopulateExpressJobExistingCars;
 
         private static PropertyInfo _AllTracksProperty;
         private static PropertyInfo _RouteTrackLengthProp;
         private static PropertyInfo _TrainCarsToTransportProp;
+        private static PropertyInfo _PaxStYardIdProperty;
 
         private static FieldInfo _RouteTrackTrackField;
         private static FieldInfo _StartingTrackField;
         private static FieldInfo _TaskStartingTrackField;
+        private static FieldInfo _RouteResultTracksField;
+        private static FieldInfo _RouteTrackStationField;
 
         private static Random _Random;
 
         private static JobType _PassengerExpress;
         private static JobType _PassengerLocal;
+
+        private static object _RouteTypeExpress;
+        private static object _RouteTypeLocal;
 
         public static bool Initialize()
         {
@@ -69,6 +87,9 @@ namespace PersistentJobsMod.ModInteraction
                 _PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
                 _PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
                 _PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
+                _RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
+                _RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
+                _ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
 
                 _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
                 _GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
@@ -78,22 +99,35 @@ namespace PersistentJobsMod.ModInteraction
                 _GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
                 _GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
                 _PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
+                _GetRoute = CompatAccess.Method(_RouteManager, "GetRoute");
+                _GetRouteType = CompatAccess.Method(_PassJobType, "GetRouteType");
+                _GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
+                _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
+                _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
 
                 _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
                 _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
                 _TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
+                _PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
 
                 _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
                 _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
                 _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
+                _RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
+                _RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
 
                 _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
                 _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
+                _PassengerJccCtor = CompatAccess.Ctor(_PassengerChainController, new[] { typeof(GameObject) });
+                _ExpressStChainDataCtor = CompatAccess.Ctor(_ExpressStationsChainData, new[] { typeof(string), Type.GetType("System.String[]") });
 
                 _Random = new Random();
 
                 _PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
                 _PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
+
+                _RouteTypeExpress = Enum.Parse(_RouteType, "Express");
+                _RouteTypeLocal = Enum.Parse(_RouteType, "Local");
 
                 _PHJD_GenJobPostfix = typeof(PaxJobsCompat).GetMethod(nameof(GenerateJob_Postfix), BindingFlags.Static | BindingFlags.NonPublic);
                 if (_PHJD_GenerateJob != null && _PHJD_GenJobPostfix != null)
@@ -123,6 +157,7 @@ namespace PersistentJobsMod.ModInteraction
             public static ConstructorInfo Ctor(Type type, Type[] args) => AccessTools.Constructor(type, args) ?? throw new MissingMethodException(type.FullName, ".ctor");
             public static PropertyInfo Property(Type type, string name) => AccessTools.Property(type, name) ?? throw new MissingMemberException(type.FullName, name);
             public static FieldInfo Field(Type type, string name) => AccessTools.Field(type, name) ?? throw new MissingFieldException(type.FullName, name);
+            public static Type IEnumerableOf(Type elementType) => typeof(IEnumerable<>).MakeGenericType(elementType);
         }
 
         private static bool TryGetGenerator(string yardId, out object generator)
@@ -139,26 +174,39 @@ namespace PersistentJobsMod.ModInteraction
             return generator != null;
         }
 
-        public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
+        //public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
+        public static bool TryGenerateJob(StationController station, JobType jobType, object startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
         {
             passengerChainController = null;
             if (!AStartGameData.carsAndJobsLoadingFinished) return false;
-            Main._modEntry.Logger.Log($"[TryGenerateJob] Attempting to generate job of type {jobType} in {yardId}");
+            if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
+            Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
 
-            if (!TryGetGenerator(yardId, out object generator))
+            /*if (!TryGetGenerator(yardId, out object generator))
             {
                 Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
                 return false;
             }
 
-            passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });
-            if (passengerChainController == null) Main._modEntry.Logger.Error("Couldn´t generate PaxJob - null from there");
+            passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });*/
+
+            if (!BuildAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
+            {
+                Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
+                return false;
+            }
+
+            if (passengerChainController == null || passengerChainController.currentJobInChain == null) Main._modEntry.Logger.Error("JobChainController or its job is null, this shouldn´t happen!"); ;
             return passengerChainController != null;
         }
 
         private static object CreateRouteTrack(object IPassDestination, Track terminalTrack) => _RouteTrackCtor.Invoke(new object[] { IPassDestination, terminalTrack });
 
         private static object CreatePassConsistInfo(object routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack, cars });
+
+        private static object CreatePassJcc(GameObject jobChainGameObject) => _PassengerJccCtor.Invoke(new object[] { jobChainGameObject });
+
+        private static object CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => _ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds });
 
         public static bool IsPaxCars(TrainCar car)
         {
@@ -178,7 +226,9 @@ namespace PersistentJobsMod.ModInteraction
 
         private static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
 
-        private static object GetStationData(string yardId) => _GetStationData?.Invoke(null, new object[] { yardId }); // output is IPassDestination : PassStationData
+        private static object GetStationData(string yardId) => _GetStationData.Invoke(null, new object[] { yardId }); // output is IPassDestination : PassStationData
+
+        private static object GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => _GetRoute?.Invoke(null, new object[] { GetStationData(yardId), routeType, existingDests, minLength });
 
         private static object GetRouteTrackByIdOrNull(string trackFullDisplayId)
         {
@@ -191,7 +241,7 @@ namespace PersistentJobsMod.ModInteraction
 
         private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
 
-        private static List<Car> GetTrainCarsForPaxJobDefinition(StaticJobDefinition staticPaxJobDefinition) => (List<Car>)_TrainCarsToTransportProp.GetValue(staticPaxJobDefinition);
+        private static string YardIdFromPaxStation(object passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData);
 
         private static IEnumerable<object> GetPlatforms(object stationData, bool onlyTerminusTracks = false)
         {
@@ -209,11 +259,25 @@ namespace PersistentJobsMod.ModInteraction
             return track;
         }
 
-        private static object GetPaxHaulJobDefStartingRouteTrackField(StaticJobDefinition staticPaxJobDefinition) => _StartingTrackField.GetValue(staticPaxJobDefinition);
+        private static object GetRouteTrackStationField(object routeTrack)
+        {
+            if (routeTrack == null) return null;
+            var iPassDest = _RouteTrackStationField.GetValue(routeTrack);
+            if (iPassDest == null) return null;
+            return iPassDest;
+        }
 
         private static double GetRouteTrackLength(object routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack);
 
+        private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
+
         private static bool CanFitInStation(object stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
+
+        private static object GetRouteType(JobType type) => _GetRouteType.Invoke(null, new object[] { type });
+
+        private static object GetRouteResultTracksArray(object routeResult) => _RouteResultTracksField.GetValue(routeResult);
+
+        private static float GetTotalHaulDistance(StationController startStation, object destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
 
         private static JobType PickPassengerJobType(int carCount)
         {
@@ -222,6 +286,8 @@ namespace PersistentJobsMod.ModInteraction
 
             return _PassengerExpress;
         }
+
+        private static object PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, object startTrack, object routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => _PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack, routeResult, logicCars, chainData, timeLimit, initialPay });
 
         private static object SelectStartPlatformRouteTrack(Track currentTrack, List<object> fittingPlatforms)
         {
@@ -278,7 +344,8 @@ namespace PersistentJobsMod.ModInteraction
 
             Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
 
-            if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
+            //if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
+            if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
                 result.Add(passangerChainController);
@@ -339,6 +406,30 @@ namespace PersistentJobsMod.ModInteraction
             return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
         }
 
+        private static void AddTransportTaskToTop(StaticJobDefinition staticPaxJobDefinition, Track currentTrack, Track destinatiionTrack, List<Car> cars)
+        {
+            if (staticPaxJobDefinition != null)
+            {
+                if (staticPaxJobDefinition.job == null)
+                {
+                    Main._modEntry.Logger.Error("staticJobDefinition.job is null");
+                    return;
+                }
+                var job = staticPaxJobDefinition.job;
+                Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
+                var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
+                if (headSequentialTask != null)
+                {
+                    var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
+                    newTransportTask.SetJobBelonging(job);
+                    headSequentialTask.tasks.AddFirst(newTransportTask);
+                }
+                else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
+            }
+            else Main._modEntry.Logger.Error($"Couldn´t get job definition");
+
+        }
+
         public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
         {
             List<JobChainController> result = new();
@@ -361,7 +452,6 @@ namespace PersistentJobsMod.ModInteraction
                 result.AddRange(jobChainControllers);
             }
 
-            //foreach (var jcc in result) if (_PassengerChainController.IsInstanceOfType(jcc)) FinalizeJobChainControllerAndGenerateFirstJob(jcc);
             return result;
         }
 
@@ -378,13 +468,14 @@ namespace PersistentJobsMod.ModInteraction
         {
             trainCarGroups.RemoveAll(trainCars =>
             {
-                if (trainCars == null || trainCars.Count < 1)
+                if (trainCars == null || trainCars.Count == 0)
                 {
                     Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid trainCars input thrown out");
                     return true;
                 }
-                var startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-                return startingTrack == null;
+                if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
+
+                return trainCars.All(tc => tc.derailed);
             });
             return trainCarGroups;
         }
@@ -422,6 +513,55 @@ namespace PersistentJobsMod.ModInteraction
             return true;
         }
 
+        private static bool BuildAndGenerateJob(StationController startingStation, object startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
+        {
+            passengerChainController = null;
+            //object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
+            var currentDests = startingStation.logicStation.availableJobs
+                .Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
+                .Select(j => j.chainData.chainDestinationYardId);
+
+            var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType), currentDests, GetConsistLength(trainCars));
+            if (destinations == null) return false;
+
+            var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
+
+            if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+            var destinationTracks = rrTracksArray.Cast<object>().Select(t => _RouteTrackTrackField.GetValue(t)).Cast<Track>().ToList();
+            var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(d)));
+
+            // create job chain controller
+            string destString = string.Join(" - ", destinationRouteTracksYardIDs);
+            var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
+            chainJobObject.transform.SetParent(startingStation.transform);
+            var chainController = (JobChainController)CreatePassJcc(chainJobObject);
+
+            var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray());
+            PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
+
+            float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
+            float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false);
+            float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
+
+            chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
+
+            var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment);
+            if (jobDefinition == null)
+            {
+                Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
+                chainController.DestroyChain();
+                return false;
+            }
+
+            chainController.AddJobDefinitionToChain(jobDefinition);
+
+            // Finalize job
+            chainController.FinalizeSetupAndGenerateFirstJob();
+            Main._modEntry.Logger.Log($"Generated new passenger haul job: {chainJobObject.name} ({chainController.currentJobInChain.ID})");
+            passengerChainController = chainController;
+            return true;
+        }
+
         private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
         {
             jobChainControllers = new();
@@ -439,7 +579,8 @@ namespace PersistentJobsMod.ModInteraction
                 }
 
                 JobType jobType = PickPassengerJobType(trainCars.Count);
-                //jobChainControllers.AddRange(TryGeneratePartialPassengerJob(station, trainCars, fittingPlatforms, jobType)); - not implemented now, need to skip first/second task (pax loading in start station), have to go deeper than PassangerJobGenerator.GenerateJob(...)
+                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal;
+                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
                 return;
             }
             else

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -4,14 +4,17 @@ using DV.Logic.Job;
 using DV.ThingTypes;
 using DV.RenderTextureSystem.BookletRender;
 using HarmonyLib;
+using MessageBox;
 using PersistentJobsMod.Extensions;
 using PersistentJobsMod.JobGenerators;
 using PersistentJobsMod.Utilities;
 using PersistentJobsMod.Persistence;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using UnityEngine;
 using static PersistentJobsMod.Utilities.ReflectionUtilities;
 using static PersistentJobsMod.HarmonyPatches.JobGeneration.UnusedTrainCarDeleter_Patches;
@@ -32,1089 +35,1218 @@ using PassengerJobDataRef = PersistentJobsMod.Utilities.ReflectionUtilities.Fore
 
 namespace PersistentJobsMod.ModInteraction
 {
-	public static class PaxJobsCompat
-	{
-		#region Reflection setup
-		private static Assembly asm;
-
-		private static Type _RouteManager;
-		private static Type _ConsistManager;
-		private static Type _RouteTrack;
-		private static Type _PassConsistInfo;
-		private static Type _PassengerJobGenerator;
-		private static Type _IPassDestination;
-		private static Type _PassJobType;
-		private static Type _PassengerChainController;
-		private static Type _PassengerHaulJobDefinition;
-		private static Type _RouteResult;
-		private static Type _RouteType;
-		private static Type _ExpressStationsChainData;
-		private static Type _PlatformController;
-		private static Type _BookletUtility;
-		private static Type _BookletCreator_JobPatch;
-		private static Type _PassengerJobData;
-		private static Type _PassStopInfo;
-		private static Type _ExpressJobDefinitionData;
-		private static Type _JobSaveManagerPatch;
-		private static Type _PassengerChainSaveData;
-
-		private static ConstructorInfo _RouteTrackCtor;
-		private static ConstructorInfo _PassConsistInfoCtor;
-		private static ConstructorInfo _PassengerJccCtor;
-		private static ConstructorInfo _ExpressStChainDataCtor;
-
-		private static MethodInfo _TryGetInstance;
-		private static MethodInfo _GenerateJob;
-		private static MethodInfo _GetPassengerCars;
-		private static MethodInfo _IsPassengerStation;
-		private static MethodInfo _GetStationData;
-		private static MethodInfo _GetRouteTrackById;
-		private static MethodInfo _GetPlatforms;
-		private static MethodInfo _PHJD_GenerateJob;
-		private static MethodInfo _GetRoute;
-		private static MethodInfo _GetRouteType;
-		private static MethodInfo _GetJobPaymentData;
-		private static MethodInfo _GetTotalHaulDistance;
-		private static MethodInfo _PopulateExpressJobExistingCars;
-		private static MethodInfo _PaxJGeneratorStartGenerationAsync;
-		private static MethodInfo _PHJD_CreateBoardingTask;
-		private static MethodInfo _PHJD_CreateTransportTask;
-		private static MethodInfo _PlatformControllerForTrack;
-		private static MethodInfo _PlatformRegisterOutgoingJob;
-		private static MethodInfo _PlatformRegisterIncomingJob;
-		private static MethodInfo _ExtractPassengerJobData;
-		private static MethodInfo _GetBookletTemplateData;
-		private static MethodInfo _CreateLoadTaskPage;
-		private static MethodInfo _CreateCoupleTaskPage;
-		private static MethodInfo _CreateCoupleTaskPaperData;
-		private static MethodInfo _LoadPassengerChain;
-
-		private static PropertyInfo _AllTracksProperty;
-		private static PropertyInfo _RouteTrackLengthProp;
-		private static PropertyInfo _TrainCarsToTransportProp;
-		private static PropertyInfo _PaxStYardIdProperty;
-		private static PropertyInfo _RTPlatformIdProp;
-
-		private static FieldInfo _RouteTrackTrackField;
-		private static FieldInfo _StartingTrackField;
-		private static FieldInfo _DestinationTracksField;
-		private static FieldInfo _TaskStartingTrackField;
-		private static FieldInfo _RouteResultTracksField;
-		private static FieldInfo _RouteTrackStationField;
-		private static FieldInfo _PaxJGeneratorStContField;
-		private static FieldInfo _PHJD_RouteTypeField;
-		private static FieldInfo _StaticJobDefJobField;
-		private static FieldInfo _InitialStopField;
-
-		private static Random _Random;
-
-		private static JobType _PassengerExpress;
-		private static JobType _PassengerLocal;
-
-		private static object _RouteTypeExpress;
-		private static object _RouteTypeLocal;
-
-		//private static UnityEngine.Object[] _AllPlatformControllers;
-
-		public static bool Initialize()
-		{
-			try
-			{
-				asm = Main.PaxJobs.Assembly;
-
-				_RouteManager = CompatAccess.Type("PassengerJobs.Generation.RouteManager");
-				_ConsistManager = CompatAccess.Type("PassengerJobs.Generation.ConsistManager");
-				_RouteTrack = CompatAccess.Type("PassengerJobs.Generation.RouteTrack");
-				_PassConsistInfo = CompatAccess.Type("PassengerJobs.Generation.PassConsistInfo");
-				_PassengerJobGenerator = CompatAccess.Type("PassengerJobs.Generation.PassengerJobGenerator");
-				_IPassDestination = CompatAccess.Type("PassengerJobs.Generation.IPassDestination");
-				_PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
-				_PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
-				_PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
-				_RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
-				_RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
-				_ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
-				_PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
-				_BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
-				_BookletCreator_JobPatch = CompatAccess.Type("PassengerJobs.Patches.BookletCreator_JobPatch");
-				_PassengerJobData = CompatAccess.Type("PassengerJobs.PassengerJobData");
-				_PassStopInfo = CompatAccess.Type("PassengerJobs.PassStopInfo");
-				_ExpressJobDefinitionData = CompatAccess.Type("PassengerJobs.Generation.ExpressJobDefinitionData");
-				_JobSaveManagerPatch = CompatAccess.Type("PassengerJobs.Patches.JobSaveManagerPatch");
-				_PassengerChainSaveData = CompatAccess.Type("PassengerJobs.Generation.PassengerChainSaveData");
-
-				_TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
-				_GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
-				_GetPassengerCars = CompatAccess.Method(_ConsistManager, "GetPassengerCars");
-				_IsPassengerStation = CompatAccess.Method(_RouteManager, "IsPassengerStation");
-				_GetStationData = CompatAccess.Method(_RouteManager, "GetStationData");
-				_GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
-				_GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
-				_PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
-				_GetRoute = CompatAccess.Method(_RouteManager, "GetRoute");
-				_GetRouteType = CompatAccess.Method(_PassJobType, "GetRouteType");
-				_GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
-				_GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
-				_PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
-				_PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
-				_PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack, typeof(float), typeof(bool), typeof(bool) });
-				_PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track) });
-				_PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] { typeof(string) });
-				_PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool) });
-				_PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool) });
-				_ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
-				_GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
-				_CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
-				_CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
-				_CreateCoupleTaskPaperData = CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) });
-				_LoadPassengerChain = CompatAccess.Method(_JobSaveManagerPatch, "LoadPassengerChain", new[] { _PassengerChainSaveData });
-
-				_AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
-				_RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
-				_TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
-				_PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
-				_RTPlatformIdProp = CompatAccess.Property(_RouteTrack, "PlatformID");
-
-				_RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
-				_StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
-				_DestinationTracksField = CompatAccess.Field(_PassengerHaulJobDefinition, "DestinationTracks");
-				_TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
-				_RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
-				_RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
-				_PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
-				_PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
-				_StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
-				_InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
-
-				_RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
-				_PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
-				_PassengerJccCtor = CompatAccess.Ctor(_PassengerChainController, new[] { typeof(GameObject) });
-				_ExpressStChainDataCtor = CompatAccess.Ctor(_ExpressStationsChainData, new[] { typeof(string), Type.GetType("System.String[]") });
-
-				_Random = new Random();
-
-				_PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
-				_PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
-
-				_RouteTypeExpress = Enum.Parse(_RouteType, "Express");
-				_RouteTypeLocal = Enum.Parse(_RouteType, "Local");
-
-				//_AllPlatformControllers ??= UnityEngine.Object.FindObjectsOfType(_PlatformController) ?? throw new KeyNotFoundException("No platform controllesr present, this shouldn´t happen");
-
-				PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
-
-				PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
-
-				PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
-
-				PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
-
-				PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
-
-				PatchPrefix(_CreateCoupleTaskPage, typeof(PaxJobsCompat), nameof(CreateCoupleTaskPage_Prefix));
-
-				PatchPostfix(_LoadPassengerChain, typeof(PaxJobsCompat), nameof(LoadPassengerChain_Postfix));
-
-			}
-			catch (Exception e)
-			{
-				Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods", e);
-				return false;
-			}
-
-			return true;
-		}
-
-		public class Tags
-		{
-			public sealed class RouteManager { };
-			public sealed class ConsistManager { };
-			public sealed class RouteTrack { };
-			public sealed class PassConsistInfo { };
-			public sealed class PassengerJobGenerator { };
-			public sealed class IPassDestination { };
-			public sealed class PassJobType { };
-			public sealed class PassengerChainController { };
-			public sealed class PassengerHaulJobDefinition { };
-			public sealed class RouteResult { };
-			public sealed class RouteType { };
-			public sealed class ExpressStationsChainData { };
-			public sealed class PlatformController { };
-			public sealed class PassengerJobData { };
-
-			public class PaxJobModifiedFlag : MonoBehaviour { };
-			public class PaxJobJobTakenFlag : MonoBehaviour { public JobChainSaveData jobChainSaveData; };
-		}
-		#endregion
-
-		public static bool OverrideSpawnFlagForPaxJ = false;
-
-		private static bool TryGetGenerator(string yardId, out object generator)
-		{
-			generator = null;
-			var args = new object[] { yardId, null };
-			if (!(bool)_TryGetInstance.Invoke(null, args))
-			{
-				Main._modEntry.Logger.Error($"Couldn´t get instance of PaxJobsGenerator for {yardId}");
-				return false;
-			}
-
-			generator = args[1];
-			return generator != null;
-		}
-
-		public static void PaxJobsOrigGenJobsInStation(string yardId)
-		{
-			if (!TryGetGenerator(yardId, out object generator))
-			{
-				Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
-				return;
-			}
-			_PaxJGeneratorStartGenerationAsync.Invoke(generator, new object[0]);
-			Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
-		}
-
-		private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
-		{
-			passengerChainController = null;
-			if (!AStartGameData.carsAndJobsLoadingFinished) return false;
-			if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
-			Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
-
-			if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
-			{
-				Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
-				return false;
-			}
-
-			if (passengerChainController == null || passengerChainController.currentJobInChain == null) Main._modEntry.Logger.Error("JobChainController or its job is null, this shouldn´t happen!"); ;
-			return passengerChainController != null;
-		}
-
-		private static RouteTrackRef CreateRouteTrack(IPassDestinationRef IPassDestination, Track terminalTrack) => new(_RouteTrackCtor.Invoke(new object[] { IPassDestination.Value, terminalTrack }));
-
-		private static object CreatePassConsistInfo(RouteTrackRef routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack.Value, cars });
-
-		private static PassengerChainControllerRef CreatePassJcc(GameObject jobChainGameObject) => new(_PassengerJccCtor.Invoke(new object[] { jobChainGameObject }));
-
-		private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
-
-		public static bool IsPaxJobDefinition(StaticJobDefinition jobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)
-		{
-			passengerHaulJobDefinition = new(null);
-			if (jobDefinition == null) return false;
-			var job = jobDefinition.job;
-			if (job == null) return false;
-			bool correctType = (job.jobType == _PassengerExpress || job.jobType == _PassengerLocal);
-			bool correctDef = _PassengerHaulJobDefinition.IsInstanceOfType(jobDefinition);
-			passengerHaulJobDefinition = new(jobDefinition);
-			return correctType && correctDef;
-		}
-
-		public static bool IsPaxCars(TrainCar car)
-		{
-			var carLiveries = (IEnumerable<TrainCarLivery>)_GetPassengerCars.Invoke(null, null);
-			return carLiveries != null && car.carLivery != null && carLiveries.Contains(car.carLivery);
-		}
-
-		public static float GetConsistLength(List<TrainCar> trainCars) => CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true);
-
-		private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
-
-		public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
-
-		private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
-
-		private static RouteResultRef GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => new(_GetRoute?.Invoke(null, new object[] { GetStationData(yardId).Value, routeType, existingDests, minLength }));
-
-		private static RouteTrackRef GetRouteTrackByIdOrNull(string trackFullDisplayId)
-		{
-			RouteTrackRef routeTrack = new(_GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId }));
-			if (routeTrack.Value is null) return new(null);
-			Track trackField = GetRouteTrackTrackField(routeTrack);
-			if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return new(null);
-			return routeTrack;
-		}
-
-		private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId).Value)).ToList();
-
-		private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
-
-		private static IEnumerable<RouteTrackRef> GetPlatforms(IPassDestinationRef stationData, bool onlyTerminusTracks = false)
-		{
-			var result = _GetPlatforms.Invoke(stationData.Value, new object[] { onlyTerminusTracks });
-			if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return new(item);
-		}
-
-		private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
-
-		private static Track GetRouteTrackTrackField(RouteTrackRef routeTrack)
-		{
-			if (routeTrack.Value == null) return null;
-			var track = (Track)_RouteTrackTrackField.GetValue(routeTrack.Value);
-			if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
-			return track;
-		}
-
-		private static IPassDestinationRef GetRouteTrackStationField(RouteTrackRef routeTrack)
-		{
-			if (routeTrack.Value == null) return new(null);
-			var iPassDest = _RouteTrackStationField.GetValue(routeTrack.Value);
-			if (iPassDest == null) return new(null);
-			return new(iPassDest);
-		}
-
-		private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
-
-		private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
-
-		private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
-
-		private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
-
-		private static bool CanFitInStation(IPassDestinationRef stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
-
-		private static RouteTypeRef GetRouteType(JobType type) => new(_GetRouteType.Invoke(null, new object[] { type }));
-
-		private static object GetRouteResultTracksArray(RouteResultRef routeResult) => _RouteResultTracksField.GetValue(routeResult.Value);
-
-		private static float GetTotalHaulDistance(StationController startStation, Array destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
-
-		private static JobType PickPassengerJobType(int carCount)
-		{
-			if (carCount <= 4)
-				return (JobType)_Random.Next(101, 103); // Express or Local
-
-			return _PassengerExpress;
-		}
-
-		private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
-
-		private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] { platform.Value, totalCapacity, loading, isFinal }));
-
-		private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack });
-
-		private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
-		{
-			if (!fittingPlatforms.Any()) return new(null);
-
-			if (currentTrack != null)
-			{
-				string currentTrackId = currentTrack.ID.FullDisplayID;
-				var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
-				{
-					var track = GetRouteTrackTrackField(rt);
-					return track != null && track.ID.FullDisplayID == currentTrackId;
-				});
-
-				if (matchingPlatform.Value != null)
-				{
-					Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
-					return matchingPlatform;
-				}
-				Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random free platform");
-			}
-			else Main._modEntry.Logger.Log("Could not determine current track, selecting random free platform");
-
-			return fittingPlatforms.OrderByDescending(p =>
-			{
-				var track = GetRouteTrackTrackField(p) ?? new Track(0);
-				return track.length - track.OccupiedLength;
-			}).FirstOrDefault();
-		}
-
-		private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<RouteTrackRef> fittingPlatforms, JobType jobType)
-		{
-			List<JobChainController> result = new();
-			if (trainCars.Count() > 20)
-			{
-				result.AddRange(HandleSplitOrFail(trainCars, station));
-				return result;
-			}
-
-			Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-			var preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
-			if (preferredRouteTrack.Value == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
-			{
-				Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
-				result.AddRange(HandleSplitOrFail(trainCars, station));
-				return result;
-			}
-
-			if (!fittingPlatforms.Contains(preferredRouteTrack))
-			{
-				Main._modEntry.Logger.Error("Selected RouteTrack is not in fitting platforms list");
-				return result;
-			}
-
-			Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
-
-			if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
-			{
-				Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
-				result.Add(passangerChainController);
-				return result;
-			}
-
-			result.AddRange(HandleSplitOrFail(trainCars, station));
-			return result;
-		}
-
-		private static List<JobChainController> HandleSplitOrFail(List<TrainCar> trainCars, StationController station)
-		{
-			List<JobChainController> result = new();
-			if (trainCars.Count < 2)
-			{
-				Main._modEntry.Logger.Error($"Single pax car {trainCars.First().ID} cannot be reassigned");
-				return result;
-			}
-
-			var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(new List<IReadOnlyList<TrainCar>> { trainCars });
-			if (emptyConsecutiveTrainCarGroups.Any())
-			{
-				foreach (var emptyTrainCars in emptyConsecutiveTrainCarGroups)
-				{
-					Main._modEntry.Logger.Log($"Spilitting consist starting with car {emptyTrainCars.First().ID}");
-					var (first, second) = emptyTrainCars.SplitInHalf();
-					HandleEmptyPaxCars(first, station, out List<JobChainController> outJobChainControllers);
-					result.AddRange(outJobChainControllers);
-					HandleEmptyPaxCars(second, station, out outJobChainControllers);
-					result.AddRange(outJobChainControllers);
-				}
-			}
-
-			if (loadedConsecutiveTrainCarGroups.Any())
-			{
-				foreach (var loadedTrainCars in loadedConsecutiveTrainCarGroups)
-				{
-					Main._modEntry.Logger.Log($"Spilitting consist starting with car {loadedTrainCars.First().ID}");
-					var (first, second) = loadedTrainCars.SplitInHalf();
-					HandleLoadedPaxCars(first, station, out List<JobChainController> outJobChainControllers);
-					result.AddRange(outJobChainControllers);
-					HandleLoadedPaxCars(second, station, out outJobChainControllers);
-					result.AddRange(outJobChainControllers);
-				}
-			}
-
-			return result;
-		}
-
-		private static (List<IReadOnlyList<TrainCar>>, List<IReadOnlyList<TrainCar>>) SortCGIntoEmptyAndLoaded(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups)
-		{
-			var statusTrainCarGroups = paxConsecutiveTrainCarGroups.SelectMany(cars => cars.GroupConsecutiveBy(tc => GetTrainCarReassignStatus(tc))).ToList();
-			var emptyConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Empty).Select(s => s.Items).ToList();
-			var loadedConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Loaded).Select(s => s.Items).ToList();
-
-			Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
-			Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
-			return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
-		}
-
-		public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
-		{
-			List<JobChainController> result = new();
-			Main._modEntry.Logger.Log($"Reassigning passanger cars to jobs in station {station.logicStation.ID}");
-
-			EnsureTrainCarsAreConvertedToNonPlayerSpawned(FilterTrainCarGroups(paxConsecutiveTrainCarGroups).SelectMany(tcg => tcg).ToList());
-
-			var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(paxConsecutiveTrainCarGroups);
-			foreach (List<TrainCar> tcs in emptyConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
-			{
-				HandleEmptyPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
-				result.AddRange(jobChainControllers);
-			}
-			foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
-			{
-				Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
-				HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
-				result.AddRange(jobChainControllers);
-			}
-
-			return result;
-		}
-
-		public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
-		{
-			trainCarGroups.RemoveAll(trainCars =>
-			{
-				if (trainCars == null || trainCars.Count == 0)
-				{
-					Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid cars input thrown out");
-					return true;
-				}
-				if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
-
-				return trainCars.All(tc => tc.derailed);
-			});
-			return trainCarGroups;
-		}
-
-		private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
-		{
-			var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID).Value != null ? (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList()) : new List<Track>();
-			return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
-		}
-
-		private static List<RouteTrackRef> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
-		{
-			var stationData = GetStationData(station.stationInfo.YardID);
-			return stationData.Value == null ? new List<RouteTrackRef>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
-		}
-
-		private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
-
-		private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
-
-		private static bool FilterJobDataForModPaxJob(ref Job_data job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit)
-		{
-			firstNestedTask = null;
-			taskSequence = null;
-
-			if (job.tasksData == null || job.tasksData.Length == 0)
-			{
-				exit = true;
-				return false;
-			}
-
-			taskSequence = job.tasksData[0];
-			if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1)
-			{
-				exit = true;
-				return false;
-			}
-
-			firstNestedTask = taskSequence.nestedTasks[0];
-			if (firstNestedTask.instanceTaskType != TaskType.Transport)
-			{
-				exit = true;
-				return true;
-			}
-
-			exit = false;
-			return false;
-		}
-
-		private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
-		{
-			startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-			if (startingTrack == null)
-			{
-				Main._modEntry.Logger.Error("No starting track found");
-				return false;
-			}
-
-			if (startingTrack.ID.yardId != station.stationInfo.YardID)
-			{
-				Main._modEntry.Logger.Error("Station mismatch");
-				return false;
-			}
-			return true;
-		}
-
-		private static bool SetupAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
-		{
-			passengerChainController = null;
-			//object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
-			var currentDests = startingStation.logicStation.availableJobs
-				.Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
-				.Select(j => j.chainData.chainDestinationYardId);
-
-			var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType).Value, currentDests, GetConsistLength(trainCars));
-			if (destinations.Value == null) return false;
-
-			var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
-
-			if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
-			var destinationTracks = rrTracksArray.Cast<object>().Select(o => new Foreign<RouteTrackRef>(o)).Select(rt => (Track)_RouteTrackTrackField.GetValue(rt.Value)).ToList();
-			var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(new RouteTrackRef(d))));
-
-			// create job chain controller
-			string destString = string.Join(" - ", destinationRouteTracksYardIDs);
-			var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
-			chainJobObject.transform.SetParent(startingStation.transform);
-			var chainController = (JobChainController)CreatePassJcc(chainJobObject).Value;
-
-			var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray()).Value;
-			PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
-
-			float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
-			float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false);
-			float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
-
-			chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
-
-			var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment).Value;
-			if (jobDefinition == null)
-			{
-				Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
-				chainController.DestroyChain();
-				return false;
-			}
-
-			chainController.AddJobDefinitionToChain(jobDefinition);
-
-			// Finalize job
-			chainController.FinalizeSetupAndGenerateFirstJob();
-			Main._modEntry.Logger.Log($"Generated new passenger haul job: {chainJobObject.name} ({chainController.currentJobInChain.ID})");
-			passengerChainController = chainController;
-			return true;
-		}
-
-		internal readonly struct PaxJobContext
-		{
+    public static class PaxJobsCompat
+    {
+        #region Reflection setup
+        private static Assembly asm;
+
+        private static Type _RouteManager;
+        private static Type _ConsistManager;
+        private static Type _RouteTrack;
+        private static Type _PassConsistInfo;
+        private static Type _PassengerJobGenerator;
+        private static Type _IPassDestination;
+        private static Type _PassJobType;
+        private static Type _PassengerChainController;
+        private static Type _PassengerHaulJobDefinition;
+        private static Type _RouteResult;
+        private static Type _RouteType;
+        private static Type _ExpressStationsChainData;
+        private static Type _PlatformController;
+        private static Type _BookletUtility;
+        private static Type _BookletCreator_JobPatch;
+        private static Type _PassengerJobData;
+        private static Type _PassStopInfo;
+        private static Type _ExpressJobDefinitionData;
+        private static Type _JobSaveManagerPatch;
+        private static Type _PassengerChainSaveData;
+        private static Type _PJMain;
+        private static Type _PJModSettings;
+        private static Type _PJExtensions;
+        private static Type _CityLoadingTask;
+        private static Type _RuralLoadingTask;
+
+        private static ConstructorInfo _RouteTrackCtor;
+        private static ConstructorInfo _PassConsistInfoCtor;
+        private static ConstructorInfo _PassengerJccCtor;
+        private static ConstructorInfo _ExpressStChainDataCtor;
+
+        private static MethodInfo _TryGetInstance;
+        private static MethodInfo _GetAllPassengerCars;
+        private static MethodInfo _IsPassengerStation;
+        private static MethodInfo _GetStationData;
+        private static MethodInfo _GetRouteTrackById;
+        private static MethodInfo _GetPlatforms;
+        private static MethodInfo _PHJD_GenerateJob;
+        private static MethodInfo _GetRoute;
+        private static MethodInfo _GetRouteType;
+        private static MethodInfo _GetJobPaymentData;
+        private static MethodInfo _GetTotalHaulDistance;
+        private static MethodInfo _PopulateExpressJobExistingCars;
+        private static MethodInfo _PaxJGeneratorStartGenerationAsync;
+        private static MethodInfo _PHJD_CreateBoardingTask;
+        private static MethodInfo _PHJD_CreateTransportTask;
+        private static MethodInfo _PlatformControllerForTrack;
+        private static MethodInfo _PlatformRegisterOutgoingJob;
+        private static MethodInfo _PlatformRegisterIncomingJob;
+        private static MethodInfo _ExtractPassengerJobData;
+        private static MethodInfo _GetBookletTemplateData;
+        private static MethodInfo _CreateLoadTaskPage;
+        private static MethodInfo _CreateCoupleTaskPage;
+        private static MethodInfo _CreateCoupleTaskPaperData;
+        private static MethodInfo _LoadPassengerChain;
+        private static MethodInfo _GetTimeMultiplier;
+        private static MethodInfo _GetTimeForStops;
+        private static MethodInfo _GetUnusedRouteTracks;
+        private static MethodInfo _LocalGetRoute;
+        private static MethodInfo _OnLastJobInChainCompletedOverride;
+        private static MethodInfo _OnLastJobInChainCompletedBase;
+
+        private static PropertyInfo _AllTracksProperty;
+        private static PropertyInfo _RouteTrackLengthProp;
+        private static PropertyInfo _RouteTrackIsSegmentProp;
+        private static PropertyInfo _TrainCarsToTransportProp;
+        private static PropertyInfo _PaxStYardIdProperty;
+        private static PropertyInfo _RTPlatformIdProp;
+        private static PropertyInfo _PJMainSettingsProp;
+
+        private static FieldInfo _RouteTrackTrackField;
+        private static FieldInfo _StartingTrackField;
+        private static FieldInfo _DestinationTracksField;
+        private static FieldInfo _TaskStartingTrackField;
+        private static FieldInfo _RouteResultTracksField;
+        private static FieldInfo _RouteTrackStationField;
+        private static FieldInfo _PaxJGeneratorStContField;
+        private static FieldInfo _PHJD_RouteTypeField;
+        private static FieldInfo _StaticJobDefJobField;
+        private static FieldInfo _InitialStopField;
+        private static FieldInfo _BaseWageScale;
+        private static FieldInfo _CustomWagesField;
+
+        private static Random _Random;
+
+        private static TaskType _CityLoadingTaskType;
+        private static TaskType _RuralLoadingTaskType;
+
+        private static JobType _PassengerExpress;
+        private static JobType _PassengerLocal;
+
+        private static object _RouteTypeExpress;
+        private static object _RouteTypeLocal;
+
+        private static double _YTO_ReserveThreshold;
+
+        public static bool Initialize()
+        {
+            try
+            {
+                asm = Main.PaxJobs.Assembly;
+
+                _RouteManager = CompatAccess.Type("PassengerJobs.Generation.RouteManager");
+                _ConsistManager = CompatAccess.Type("PassengerJobs.Generation.ConsistManager");
+                _RouteTrack = CompatAccess.Type("PassengerJobs.Generation.RouteTrack");
+                _PassConsistInfo = CompatAccess.Type("PassengerJobs.Generation.PassConsistInfo");
+                _PassengerJobGenerator = CompatAccess.Type("PassengerJobs.Generation.PassengerJobGenerator");
+                _IPassDestination = CompatAccess.Type("PassengerJobs.Generation.IPassDestination");
+                _PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
+                _PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
+                _PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
+                _RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
+                _RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
+                _ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
+                _PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
+                _BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
+                _BookletCreator_JobPatch = CompatAccess.Type("PassengerJobs.Patches.BookletCreator_JobPatch");
+                _PassengerJobData = CompatAccess.Type("PassengerJobs.PassengerJobData");
+                _PassStopInfo = CompatAccess.Type("PassengerJobs.PassStopInfo");
+                _ExpressJobDefinitionData = CompatAccess.Type("PassengerJobs.Generation.ExpressJobDefinitionData");
+                _JobSaveManagerPatch = CompatAccess.Type("PassengerJobs.Patches.JobSaveManagerPatch");
+                _PassengerChainSaveData = CompatAccess.Type("PassengerJobs.Generation.PassengerChainSaveData");
+                _PJMain = CompatAccess.Type("PassengerJobs.PJMain");
+                _PJModSettings = CompatAccess.Type("PassengerJobs.PJModSettings");
+                _PJExtensions = CompatAccess.Type("PassengerJobs.Extensions");
+                _CityLoadingTask = CompatAccess.Type("PassengerJobs.Platforms.CityLoadingTask");
+                _RuralLoadingTask = CompatAccess.Type("PassengerJobs.Platforms.RuralLoadingTask");
+
+                _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
+                _GetAllPassengerCars = CompatAccess.Method(_ConsistManager, "GetAllPassengerCars");
+                _IsPassengerStation = CompatAccess.Method(_RouteManager, "IsPassengerStation");
+                _GetStationData = CompatAccess.Method(_RouteManager, "GetStationData");
+                _GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
+                _GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
+                _PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
+                _GetRoute = CompatAccess.Method(_RouteManager, "GetRoute");
+                _GetRouteType = CompatAccess.Method(_PassJobType, "GetRouteType");
+                _GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
+                _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
+                _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
+                _PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
+                _PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack, typeof(float), typeof(bool), typeof(bool) });
+                _PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track) });
+                _PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] { typeof(string) });
+                _PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool) });
+                _PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool) });
+                _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
+                _GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
+                _CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
+                _CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
+                _CreateCoupleTaskPaperData = CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) });
+                _LoadPassengerChain = CompatAccess.Method(_JobSaveManagerPatch, "LoadPassengerChain", new[] { _PassengerChainSaveData });
+                _GetTimeMultiplier = CompatAccess.Method(_PassengerJobGenerator, "GetTimeMultiplier", new[] { typeof(JobType) });
+                _GetTimeForStops = CompatAccess.Method(_PassengerJobGenerator, "GetTimeForStops", new[] { _RouteResult });
+                _GetUnusedRouteTracks = CompatAccess.Method(_PJExtensions, "GetUnusedTracks", new[] { CompatAccess.IEnumerableOf(_RouteTrack) });
+                _LocalGetRoute = CompatAccess.Method(typeof(PaxJobsCompat), "GetRoute");
+                _OnLastJobInChainCompletedOverride = CompatAccess.Method(_PassengerChainController, "OnLastJobInChainCompleted", new[] { typeof(Job) });
+                _OnLastJobInChainCompletedBase = CompatAccess.Method(typeof(JobChainController), "OnLastJobInChainCompleted", new[] { typeof(Job) });
+
+                _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
+                _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
+                _RouteTrackIsSegmentProp = CompatAccess.Property(_RouteTrack, "IsSegment");
+                _TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
+                _PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
+                _RTPlatformIdProp = CompatAccess.Property(_RouteTrack, "PlatformID");
+                _PJMainSettingsProp = CompatAccess.Property(_PJMain, "Settings");
+
+                _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
+                _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
+                _DestinationTracksField = CompatAccess.Field(_PassengerHaulJobDefinition, "DestinationTracks");
+                _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
+                _RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
+                _RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
+                _PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
+                _PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
+                _StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
+                _InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
+                _BaseWageScale = CompatAccess.Field(_PassengerJobGenerator, "BASE_WAGE_SCALE");
+                _CustomWagesField = CompatAccess.Field(_PJModSettings, "UseCustomWages");
+
+                _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
+                _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
+                _PassengerJccCtor = CompatAccess.Ctor(_PassengerChainController, new[] { typeof(GameObject) });
+                _ExpressStChainDataCtor = CompatAccess.Ctor(_ExpressStationsChainData, new[] { typeof(string), Type.GetType("System.String[]") });
+
+                _Random = new Random();
+
+                _CityLoadingTaskType = Traverse.Create(_CityLoadingTask).Field("TaskType").GetValue<TaskType>();
+                _RuralLoadingTaskType = Traverse.Create(_RuralLoadingTask).Field("TaskType").GetValue<TaskType>();
+
+                _PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
+                _PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
+
+                _RouteTypeExpress = Enum.Parse(_RouteType, "Express");
+                _RouteTypeLocal = Enum.Parse(_RouteType, "Local");
+
+                _YTO_ReserveThreshold = (float)CompatAccess.Field(typeof(YardTracksOrganizer), "END_OF_TRACK_OFFSET_RESERVATION").GetValue(YardTracksOrganizer.Instance) + (float)CompatAccess.Field(typeof(YardTracksOrganizer), "FLOATING_POINT_IMPRECISION_THRESHOLD").GetValue(YardTracksOrganizer.Instance);
+
+                PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
+
+                PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
+
+                PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
+
+                PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
+
+                PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
+
+                PatchPrefix(_CreateCoupleTaskPage, typeof(PaxJobsCompat), nameof(CreateCoupleTaskPage_Prefix));
+
+                PatchPostfix(_LoadPassengerChain, typeof(PaxJobsCompat), nameof(LoadPassengerChain_Postfix));
+
+                PatchPrefix(_GetUnusedRouteTracks, typeof(PaxJobsCompat), nameof(GetUnusedRouteTracks_Prefix));
+
+                PatchPrefix(_OnLastJobInChainCompletedOverride, typeof(PaxJobsCompat), nameof(OnLastJobInChainCompletedOverride_Prefix));
+
+                PatchReverse(_OnLastJobInChainCompletedBase, typeof(PaxJobsCompat), nameof(OnLastJobInChainCompletedReverse));
+
+                //removing a PaxJobs patch that deletes cars on job abandonment
+                Main.Harmony.Unpatch(CompatAccess.Method(typeof(JobChainController), "OnAnyJobFromChainAbandoned"), HarmonyPatchType.Prefix, Main.PaxJobs.Info.Id);
+
+            }
+            catch (Exception e)
+            {
+                Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods, trying to unpatch", e);
+
+                StringBuilder s = new();
+                foreach (var (target, patchContainer, patchMethodName) in ReflectionUtilities.patchRecord)
+                {
+                    try
+                    {
+                        Main.Harmony.Unpatch(target, HarmonyPatchType.All, Main.Harmony.Id);
+                    }
+                    catch (Exception ex)
+                    {
+                        Main._modEntry.Logger.LogException($"Error when unpatching {target.Name}!", ex);
+                        s.AppendLine(target.Name + ": " + ex.Message);
+                    }
+                }
+                if (s.Length > 0) PopupAPI.ShowOk("State is not clean, there might be problems. \n" + s);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        public class Tags
+        {
+            public sealed class RouteManager { };
+            public sealed class ConsistManager { };
+            public sealed class RouteTrack { };
+            public sealed class PassConsistInfo { };
+            public sealed class PassengerJobGenerator { };
+            public sealed class IPassDestination { };
+            public sealed class PassJobType { };
+            public sealed class PassengerChainController { };
+            public sealed class PassengerHaulJobDefinition { };
+            public sealed class RouteResult { };
+            public sealed class RouteType { };
+            public sealed class ExpressStationsChainData { };
+            public sealed class PlatformController { };
+            public sealed class PassengerJobData { };
+
+            public class PaxJobModifiedFlag : MonoBehaviour { };
+            public class PaxJobJobTakenFlag : MonoBehaviour { public JobChainSaveData jobChainSaveData; };
+        }
+        #endregion
+
+        public static bool OverrideSpawnFlagForPaxJ = false;
+        public static bool BypassUnusedTracksFilter = false;
+
+        private static bool TryGetGenerator(string yardId, out object generator)
+        {
+            generator = null;
+            var args = new object[] { yardId, null };
+            if (!(bool)_TryGetInstance.Invoke(null, args))
+            {
+                Main._modEntry.Logger.Error($"Couldn´t get instance of PaxJobsGenerator for {yardId}");
+                return false;
+            }
+
+            generator = args[1];
+            return generator != null;
+        }
+
+        public static void PaxJobsOrigGenJobsInStation(string yardId)
+        {
+            if (!TryGetGenerator(yardId, out object generator))
+            {
+                Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
+                return;
+            }
+            _PaxJGeneratorStartGenerationAsync.Invoke(generator, new object[0]);
+            Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
+        }
+
+        private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
+        {
+            passengerChainController = null;
+            if (!AStartGameData.carsAndJobsLoadingFinished) return false;
+            if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
+            Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
+
+            if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
+            {
+                Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
+                return false;
+            }
+
+            if (passengerChainController == null || passengerChainController.currentJobInChain == null) Main._modEntry.Logger.Error("JobChainController or its job is null, this shouldn´t happen!"); ;
+            return passengerChainController != null;
+        }
+
+        private static RouteTrackRef CreateRouteTrack(IPassDestinationRef IPassDestination, Track terminalTrack) => new(_RouteTrackCtor.Invoke(new object[] { IPassDestination.Value, terminalTrack }));
+
+        private static object CreatePassConsistInfo(RouteTrackRef routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack.Value, cars });
+
+        private static PassengerChainControllerRef CreatePassJcc(GameObject jobChainGameObject) => new(_PassengerJccCtor.Invoke(new object[] { jobChainGameObject }));
+
+        private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
+
+        public static bool IsPaxJobDefinition(StaticJobDefinition jobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)
+        {
+            passengerHaulJobDefinition = new(null);
+            if (jobDefinition == null) return false;
+            var job = jobDefinition.job;
+            if (job == null) return false;
+            bool correctType = (job.jobType == _PassengerExpress || job.jobType == _PassengerLocal);
+            bool correctDef = _PassengerHaulJobDefinition.IsInstanceOfType(jobDefinition);
+            passengerHaulJobDefinition = new(jobDefinition);
+            return correctType && correctDef;
+        }
+
+        public static bool IsPaxCars(TrainCar car)
+        {
+            var carLiveries = (IEnumerable<TrainCarLivery>)_GetAllPassengerCars.Invoke(null, null);
+            return carLiveries != null && car.carLivery != null && carLiveries.Contains(car.carLivery);
+        }
+
+        public static float GetConsistLength(List<TrainCar> trainCars) => CarSpawner.Instance.GetTotalCarsLength(TrainCar.ExtractLogicCars(trainCars), true);
+
+        private static float GetTimeMultiplier(JobType jobType) => (float)(_GetTimeMultiplier.Invoke(null, new object[] { jobType }));
+
+        private static float GetTimeForStops(RouteResultRef route) => (float)(_GetTimeForStops.Invoke(null, new object[] { route.Value }));
+
+        private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
+
+        public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
+
+        private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
+
+        private static RouteResultRef GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0)
+        {
+            BypassUnusedTracksFilter = true;
+            try
+            {
+                return new(_GetRoute?.Invoke(null, new object[] { GetStationData(yardId).Value, routeType, existingDests, minLength }));
+            }
+            finally
+            {
+                BypassUnusedTracksFilter = false;
+            }
+        }
+
+        private static RouteTrackRef GetRouteTrackByIdOrNull(string trackFullDisplayId)
+        {
+            RouteTrackRef routeTrack = new(_GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId }));
+            if (routeTrack.Value is null) return new(null);
+            Track trackField = GetRouteTrackTrackField(routeTrack);
+            if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return new(null);
+            return routeTrack;
+        }
+
+        private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId).Value)).ToList();
+
+        private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
+
+        private static IEnumerable<RouteTrackRef> GetPlatforms(IPassDestinationRef stationData, bool onlyTerminusTracks = false)
+        {
+            var result = _GetPlatforms.Invoke(stationData.Value, new object[] { onlyTerminusTracks });
+            if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return new(item);
+        }
+
+        private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
+
+        private static Track GetRouteTrackTrackField(RouteTrackRef routeTrack)
+        {
+            if (routeTrack.Value == null) return null;
+            var track = (Track)_RouteTrackTrackField.GetValue(routeTrack.Value);
+            if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
+            return track;
+        }
+
+        private static IPassDestinationRef GetRouteTrackStationField(RouteTrackRef routeTrack)
+        {
+            if (routeTrack.Value == null) return new(null);
+            var iPassDest = _RouteTrackStationField.GetValue(routeTrack.Value);
+            if (iPassDest == null) return new(null);
+            return new(iPassDest);
+        }
+
+        private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
+
+        private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
+
+        private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
+
+        private static bool IsRouteTrackASegment(RouteTrackRef routeTrack) => (bool)_RouteTrackIsSegmentProp.GetValue(routeTrack.Value);
+
+        private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
+
+        private static bool CanFitInStation(IPassDestinationRef stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
+
+        private static RouteTypeRef GetRouteType(JobType type) => new(_GetRouteType.Invoke(null, new object[] { type }));
+
+        private static object GetRouteResultTracksArray(RouteResultRef routeResult) => _RouteResultTracksField.GetValue(routeResult.Value);
+
+        private static float GetTotalHaulDistance(StationController startStation, Array destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
+
+        private static JobType PickPassengerJobType(int carCount)
+        {
+            if (carCount <= 4)
+                return (JobType)_Random.Next(101, 103); // Express or Local
+
+            return _PassengerExpress;
+        }
+
+        private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
+
+        private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] { platform.Value, totalCapacity, loading, isFinal }));
+
+        private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack });
+
+        private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
+        {
+            if (!fittingPlatforms.Any()) return new(null);
+
+            if (currentTrack != null)
+            {
+                string currentTrackId = currentTrack.ID.FullDisplayID;
+                var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
+                {
+                    var track = GetRouteTrackTrackField(rt);
+                    return track != null && track.ID.FullDisplayID == currentTrackId;
+                });
+
+                if (matchingPlatform.Value != null)
+                {
+                    Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
+                    return matchingPlatform;
+                }
+                Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random free platform");
+            }
+            else Main._modEntry.Logger.Log("Could not determine current track, selecting random free platform");
+
+            return fittingPlatforms.OrderByDescending(p =>
+            {
+                var track = GetRouteTrackTrackField(p) ?? new Track(0);
+                return track.length - track.OccupiedLength;
+            }).FirstOrDefault();
+        }
+
+        private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<RouteTrackRef> fittingPlatforms, JobType jobType)
+        {
+            List<JobChainController> result = new();
+            if (trainCars.Count() > 20)
+            {
+                result.AddRange(HandleSplitOrFail(trainCars, station));
+                return result;
+            }
+
+            Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+            var preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
+            if (preferredRouteTrack.Value == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
+            {
+                Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
+                result.AddRange(HandleSplitOrFail(trainCars, station));
+                return result;
+            }
+
+            if (!fittingPlatforms.Contains(preferredRouteTrack))
+            {
+                Main._modEntry.Logger.Error("Selected RouteTrack is not in fitting platforms list");
+                return result;
+            }
+
+            Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
+
+            if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
+            {
+                Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
+                result.Add(passangerChainController);
+                return result;
+            }
+
+            result.AddRange(HandleSplitOrFail(trainCars, station));
+            return result;
+        }
+
+        private static List<JobChainController> HandleSplitOrFail(List<TrainCar> trainCars, StationController station)
+        {
+            List<JobChainController> result = new();
+            if (trainCars.Count < 2)
+            {
+                Main._modEntry.Logger.Error($"Single pax car {trainCars.First().ID} cannot be reassigned");
+                return result;
+            }
+
+            var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(new List<IReadOnlyList<TrainCar>> { trainCars });
+            if (emptyConsecutiveTrainCarGroups.Any())
+            {
+                foreach (var emptyTrainCars in emptyConsecutiveTrainCarGroups)
+                {
+                    Main._modEntry.Logger.Log($"Spilitting consist starting with car {emptyTrainCars.First().ID}");
+                    var (first, second) = emptyTrainCars.SplitInHalf();
+                    HandleEmptyPaxCars(first, station, out List<JobChainController> outJobChainControllers);
+                    result.AddRange(outJobChainControllers);
+                    HandleEmptyPaxCars(second, station, out outJobChainControllers);
+                    result.AddRange(outJobChainControllers);
+                }
+            }
+
+            if (loadedConsecutiveTrainCarGroups.Any())
+            {
+                foreach (var loadedTrainCars in loadedConsecutiveTrainCarGroups)
+                {
+                    Main._modEntry.Logger.Log($"Spilitting consist starting with car {loadedTrainCars.First().ID}");
+                    var (first, second) = loadedTrainCars.SplitInHalf();
+                    HandleLoadedPaxCars(first, station, out List<JobChainController> outJobChainControllers);
+                    result.AddRange(outJobChainControllers);
+                    HandleLoadedPaxCars(second, station, out outJobChainControllers);
+                    result.AddRange(outJobChainControllers);
+                }
+            }
+
+            return result;
+        }
+
+        private static (List<IReadOnlyList<TrainCar>>, List<IReadOnlyList<TrainCar>>) SortCGIntoEmptyAndLoaded(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups)
+        {
+            var statusTrainCarGroups = paxConsecutiveTrainCarGroups.SelectMany(cars => cars.GroupConsecutiveBy(tc => GetTrainCarReassignStatus(tc))).ToList();
+            var emptyConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Empty).Select(s => s.Items).ToList();
+            var loadedConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Loaded).Select(s => s.Items).ToList();
+
+            Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+            Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+            return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
+        }
+
+        public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
+        {
+            List<JobChainController> result = new();
+            Main._modEntry.Logger.Log($"Reassigning passanger cars to jobs in station {station.logicStation.ID}");
+
+            EnsureTrainCarsAreConvertedToNonPlayerSpawned(FilterTrainCarGroups(paxConsecutiveTrainCarGroups).SelectMany(tcg => tcg).ToList());
+
+            var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(paxConsecutiveTrainCarGroups);
+            foreach (List<TrainCar> tcs in emptyConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+            {
+                HandleEmptyPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
+                result.AddRange(jobChainControllers);
+            }
+            foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+            {
+                Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
+                HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
+                result.AddRange(jobChainControllers);
+            }
+
+            return result;
+        }
+
+        public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
+        {
+            trainCarGroups.RemoveAll(trainCars =>
+            {
+                if (trainCars == null || trainCars.Count == 0)
+                {
+                    Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid cars input thrown out");
+                    return true;
+                }
+                if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
+
+                return trainCars.All(tc => tc.derailed);
+            });
+            return trainCarGroups;
+        }
+
+        private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
+        {
+            var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID).Value != null ? (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList()) : new List<Track>();
+            return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
+        }
+
+        private static List<RouteTrackRef> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
+        {
+            var stationData = GetStationData(station.stationInfo.YardID);
+            return stationData.Value == null ? new List<RouteTrackRef>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
+        }
+
+        private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
+
+        private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
+
+        private static bool FilterJobDataForModPaxJob(ref Job_data job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit)
+        {
+            firstNestedTask = null;
+            taskSequence = null;
+
+            if (job.tasksData == null || job.tasksData.Length == 0)
+            {
+                exit = true;
+                return false;
+            }
+
+            taskSequence = job.tasksData[0];
+            if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1)
+            {
+                exit = true;
+                return false;
+            }
+
+            firstNestedTask = taskSequence.nestedTasks[0];
+            if (firstNestedTask.instanceTaskType != TaskType.Transport)
+            {
+                exit = true;
+                return true;
+            }
+
+            exit = false;
+            return false;
+        }
+
+        private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
+        {
+            startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+            if (startingTrack == null)
+            {
+                Main._modEntry.Logger.Error("No starting track found");
+                return false;
+            }
+
+            if (startingTrack.ID.yardId != station.stationInfo.YardID)
+            {
+                Main._modEntry.Logger.Error("Station mismatch");
+                return false;
+            }
+            return true;
+        }
+
+        private static bool SetupAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
+        {
+            passengerChainController = null;
+            var currentDests = startingStation.logicStation.availableJobs
+                .Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
+                .Select(j => j.chainData.chainDestinationYardId);
+
+            RouteResultRef destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType).Value, currentDests, GetConsistLength(trainCars));
+            if (destinations.Value == null)
+            {
+                Main._modEntry.Logger.Error("destinations are null");
+                return false;
+            }
+
+            var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
+
+            if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new Foreign<RouteTrackRef>(o)).Select(rt => (Track)_RouteTrackTrackField.GetValue(rt.Value)).ToList();
+            var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(new RouteTrackRef(d))));
+
+            // create job chain controller
+            string destString = string.Join(" - ", destinationRouteTracksYardIDs);
+            var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
+            chainJobObject.transform.SetParent(startingStation.transform);
+            var chainController = (JobChainController)CreatePassJcc(chainJobObject).Value;
+
+            var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray()).Value;
+            PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
+
+            float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
+            float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false) * GetTimeMultiplier(jobType);
+            bonusLimit += GetTimeForStops(destinations);
+            float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
+            float? wageScale = 1;
+            if (TryGetGenerator(startingStation.logicStation.ID, out object generator))
+            {
+                wageScale = (float)((bool)_CustomWagesField?.GetValue(_PJMainSettingsProp.GetValue(null)) ? _BaseWageScale?.GetValue(generator) : 1);
+            }
+            transportPayment = Mathf.Round((float)(transportPayment * wageScale));
+
+            chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
+
+            var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment).Value;
+            if (jobDefinition == null)
+            {
+                Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
+                chainController.DestroyChain();
+                return false;
+            }
+
+            chainController.AddJobDefinitionToChain(jobDefinition);
+
+            // Finalize job
+            chainController.FinalizeSetupAndGenerateFirstJob();
+            Main._modEntry.Logger.Log($"Generated new passenger haul job: {chainJobObject.name} ({chainController.currentJobInChain.ID})");
+            passengerChainController = chainController;
+            return true;
+        }
+
+        internal readonly struct PaxJobContext
+        {
 #nullable enable
-			public readonly object JobDefinitionInstance;
-			public readonly StaticJobDefinition BaseJobDefinition;
-			public readonly JobChainSaveData? JobChainSaveData;
+            public readonly object JobDefinitionInstance;
+            public readonly StaticJobDefinition BaseJobDefinition;
+            public readonly JobChainSaveData? JobChainSaveData;
 
-			public readonly string ForcedJobId;
-			public readonly bool FromSave;
-			public readonly bool JobTaken;
+            public readonly JobType JobType;
+            public readonly string ForcedJobId;
+            public readonly bool FromSave;
+            public readonly bool JobTaken;
 
-			public readonly Station OriginStation;
-			public readonly float TimeLimit;
-			public readonly float InitialWage;
-			public readonly JobLicenses RequiredLicenses;
+            public readonly Station OriginStation;
+            public readonly float TimeLimit;
+            public readonly float InitialWage;
+            public readonly JobLicenses RequiredLicenses;
 
-			public readonly IReadOnlyList<Car> Cars;
-			public readonly float TotalCapacity;
-			public readonly bool CarsLoaded;
+            public readonly IReadOnlyList<Car> Cars;
+            public readonly float TotalCapacity;
+            public readonly bool CarsLoaded;
 
-			public readonly RouteTrackRef StartingRouteTrack;
-			public readonly Track StartingTrack;
-			public readonly Track CarsCurrentTrack;
+            public readonly RouteTrackRef StartingRouteTrack;
+            public readonly Track StartingTrack;
+            public readonly Track CarsCurrentTrack;
 
-			public readonly IReadOnlyList<RouteTrackRef> DestinationRouteTracks;
-			public readonly IReadOnlyList<Track> DestinationTracks;
+            public readonly IReadOnlyList<RouteTrackRef> DestinationRouteTracks;
+            public readonly IReadOnlyList<Track> DestinationTracks;
 
-			public readonly bool WasModifiedAtSave;
+            public readonly bool WasModifiedAtSave;
 
-			public PaxJobContext(object jobDefinitionInstance, JobChainSaveData jobChainSaveData, Station originStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, IReadOnlyList<Car> cars, RouteTrackRef startingRouteTrack, IReadOnlyList<RouteTrackRef> destinationRouteTracks, bool jobTaken, bool wasModifiedAtSave)
-			{
-				JobDefinitionInstance = jobDefinitionInstance;
-				BaseJobDefinition = (StaticJobDefinition)jobDefinitionInstance;
-				JobChainSaveData = jobChainSaveData;
+            public PaxJobContext(object jobDefinitionInstance, JobChainSaveData jobChainSaveData, Station originStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, IReadOnlyList<Car> cars, RouteTrackRef startingRouteTrack, IReadOnlyList<RouteTrackRef> destinationRouteTracks, bool jobTaken, bool wasModifiedAtSave)
+            {
+                JobDefinitionInstance = jobDefinitionInstance;
+                BaseJobDefinition = (StaticJobDefinition)jobDefinitionInstance;
+                JobChainSaveData = jobChainSaveData;
 
-				OriginStation = originStation;
-				TimeLimit = timeLimit;
-				InitialWage = initialWage;
-				ForcedJobId = forcedJobId;
-				FromSave = !string.IsNullOrEmpty(forcedJobId);
-				JobTaken = jobTaken;
-				WasModifiedAtSave = wasModifiedAtSave;
-				RequiredLicenses = requiredLicenses;
+                OriginStation = originStation;
+                TimeLimit = timeLimit;
+                InitialWage = initialWage;
+                ForcedJobId = forcedJobId;
+                FromSave = !string.IsNullOrEmpty(forcedJobId);
+                JobTaken = jobTaken;
+                WasModifiedAtSave = wasModifiedAtSave;
+                RequiredLicenses = requiredLicenses;
 
-				Cars = cars;
-				CarsLoaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
-				TotalCapacity = cars.Sum(c => c.capacity);
+                JobType = _PHJD_RouteTypeField.GetValue(JobDefinitionInstance).Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
 
-				StartingRouteTrack = startingRouteTrack;
-				StartingTrack = GetRouteTrackTrackField(startingRouteTrack);
-				CarsCurrentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars((List<Car>)cars));
+                Cars = cars;
+                CarsLoaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
+                TotalCapacity = cars.Sum(c => c.capacity);
 
-				DestinationRouteTracks = destinationRouteTracks;
-				DestinationTracks = destinationRouteTracks.Select(rt => GetRouteTrackTrackField(rt)).ToArray();
-			}
+                StartingRouteTrack = startingRouteTrack;
+                StartingTrack = GetRouteTrackTrackField(startingRouteTrack);
+                CarsCurrentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars((List<Car>)cars));
+
+                DestinationRouteTracks = destinationRouteTracks;
+                DestinationTracks = destinationRouteTracks.Select(rt => GetRouteTrackTrackField(rt)).ToArray();
+            }
 #nullable disable
-		}
+        }
 
-		internal enum PaxJobGenerationMode
-		{
-			None,
-			Empty_OnPlatform,
-			Empty_OffPlatform,
-			Loaded,
-			Loaded_Taken_From_Empty,
-			Loaded_Taken_From_Loaded,
-			Empty_Taken
-		}
+        internal enum PaxJobGenerationMode
+        {
+            None,
+            Empty_OnPlatform,
+            Empty_OffPlatform,
+            Loaded,
+            Loaded_Taken_From_Empty,
+            Loaded_Taken_From_Loaded,
+            Empty_Taken
+        }
 
-		private static PaxJobGenerationMode GetPaxJobGenerationMode(PaxJobContext genCtx)
-		{
-			if (!genCtx.JobTaken)
-			{
-				if (genCtx.CarsLoaded) return PaxJobGenerationMode.Loaded;
-				if (genCtx.CarsCurrentTrack == genCtx.StartingTrack) return PaxJobGenerationMode.Empty_OnPlatform;
-				else return PaxJobGenerationMode.Empty_OffPlatform;
-			}
-			else
-			{
-				if (genCtx.CarsLoaded)
-				{
-					var chainSaveData = genCtx.JobChainSaveData;
-					if (!(chainSaveData == null || chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0))
-					{
-						var headTask = chainSaveData.currentJobTaskData[0];
-						if ((headTask.type == TaskType.Sequential) && (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0))
-						{
-							//there are two warehouse tasks for each intermediate stations + the initial load + final unload
-							int numWarehouseTasks = complexData.tasksData.Count(tsd => tsd.type == TaskType.Warehouse);
-							if ((numWarehouseTasks % 2) == 0) return PaxJobGenerationMode.Loaded_Taken_From_Empty;
-							else return PaxJobGenerationMode.Loaded_Taken_From_Loaded;
-						}
-					}
-				}
-				else
-				{
-					return PaxJobGenerationMode.Empty_Taken;
-				}
-			}
+        private static PaxJobGenerationMode GetPaxJobGenerationMode(PaxJobContext genCtx)
+        {
+            if (!genCtx.JobTaken)
+            {
+                if (genCtx.CarsLoaded) return PaxJobGenerationMode.Loaded;
+                if (genCtx.CarsCurrentTrack == genCtx.StartingTrack) return PaxJobGenerationMode.Empty_OnPlatform;
+                else return PaxJobGenerationMode.Empty_OffPlatform;
+            }
+            else
+            {
+                if (genCtx.CarsLoaded)
+                {
+                    var chainSaveData = genCtx.JobChainSaveData;
+                    if (!(chainSaveData == null || chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0))
+                    {
+                        var headTask = chainSaveData.currentJobTaskData[0];
+                        if ((headTask.type == TaskType.Sequential) && (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0))
+                        {
+                            //there are two warehouse tasks for each intermediate stations + the initial load + final unload - cahnged in PaxJ v.5.2, logic should still apply tho
+                            int numWarehouseTasks = complexData.tasksData.Count(tsd => tsd.type == _CityLoadingTaskType);
+                            if (numWarehouseTasks < 1) Main._modEntry.Logger.Error("Unexpected task structure for job " + genCtx.ForcedJobId);
+                            if ((numWarehouseTasks % 2) == 0) return PaxJobGenerationMode.Loaded_Taken_From_Empty;
+                            else return PaxJobGenerationMode.Loaded_Taken_From_Loaded;
+                        }
+                    }
+                }
+                else
+                {
+                    return PaxJobGenerationMode.Empty_Taken;
+                }
+            }
 
-			return PaxJobGenerationMode.None;
-		}
+            return PaxJobGenerationMode.None;
+        }
 
-		private static void DestinationsTasks(ref List<Task> taskList, PaxJobContext genCtx)
-		{
-			var destinationTracks = genCtx.DestinationRouteTracks;
-			for (int i = 0; i < destinationTracks.Count; i++)
-			{
-				bool isLast = (i == (destinationTracks.Count - 1));
-				var unloadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, false, isLast, genCtx.JobDefinitionInstance);
-				taskList.Add(unloadTask);
+        private static void DestinationsTasks(ref List<Task> taskList, PaxJobContext genCtx)
+        {
+            var destinationTracks = genCtx.DestinationRouteTracks;
+            for (int i = 0; i < destinationTracks.Count; i++)
+            {
+                bool isLast = (i == (destinationTracks.Count - 1));
+                var unloadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, false, isLast, genCtx.JobDefinitionInstance);
+                taskList.Add(unloadTask);
 
-				if (!isLast)
-				{
-					var loadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance);
-					taskList.Add(loadTask);
-				}
-			}
-		}
+                if (!isLast)
+                {
+                    var loadTask = CreatePaxBoardingTask(destinationTracks[i], genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance);
+                    taskList.Add(loadTask);
+                }
+            }
+        }
 
-		private static SequentialTasks BuildUpTasks(PaxJobContext genCtx, PaxJobGenerationMode mode)
-		{
-			var taskList = new List<Task>();
+        private static SequentialTasks BuildUpTasks(PaxJobContext genCtx, PaxJobGenerationMode mode)
+        {
+            var taskList = new List<Task>();
 
-			switch (mode)
-			{
-				case PaxJobGenerationMode.Empty_OnPlatform:
-					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+            switch (mode)
+            {
+                case PaxJobGenerationMode.Empty_OnPlatform:
+                    taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				case PaxJobGenerationMode.Empty_OffPlatform:
-					taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
-					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+                case PaxJobGenerationMode.Empty_OffPlatform:
+                    taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+                    taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				case PaxJobGenerationMode.Loaded:
-					taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.CarsCurrentTrack, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+                case PaxJobGenerationMode.Loaded:
+                    taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.CarsCurrentTrack, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				case PaxJobGenerationMode.Loaded_Taken_From_Empty:
-					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
-					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+                case PaxJobGenerationMode.Loaded_Taken_From_Empty:
+                    if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+                    taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				case PaxJobGenerationMode.Loaded_Taken_From_Loaded:
-					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+                case PaxJobGenerationMode.Loaded_Taken_From_Loaded:
+                    if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.StartingTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				case PaxJobGenerationMode.Empty_Taken:
-					if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
-					taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
-					DestinationsTasks(ref taskList, genCtx);
-					break;
+                case PaxJobGenerationMode.Empty_Taken:
+                    if (genCtx.WasModifiedAtSave) taskList.Add(CreatePaxTransportTask(genCtx.CarsCurrentTrack, genCtx.StartingTrack, genCtx.JobDefinitionInstance));
+                    taskList.Add(CreatePaxBoardingTask(genCtx.StartingRouteTrack, genCtx.TotalCapacity, true, false, genCtx.JobDefinitionInstance));
+                    DestinationsTasks(ref taskList, genCtx);
+                    break;
 
-				default:
-					throw new InvalidOperationException("Task list could not be built!");
-			}
+                default:
+                    throw new InvalidOperationException("Task list could not be built! Mode was: " + mode.ToString());
+            }
 
-			return new(taskList);
-		}
+            return new(taskList);
+        }
 
-		private static bool GeneratePaxJob(PaxJobContext genCtx)
-		{
-			try
-			{
-				var genMode = GetPaxJobGenerationMode(genCtx);
-				var chainData = (StationsChainData)CreateExpressStationsChainData(genCtx.OriginStation.ID, genCtx.DestinationRouteTracks.Select(rt => (GetRouteTrackTrackField(rt)).ID.yardId).ToArray()).Value;
-				var superTask = BuildUpTasks(genCtx, genMode);
-				var currentRouteType = _PHJD_RouteTypeField.GetValue(genCtx.JobDefinitionInstance);
-				var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
-				var newJob = new Job(superTask, jobType, genCtx.TimeLimit, genCtx.InitialWage, chainData, genCtx.ForcedJobId, genCtx.RequiredLicenses);
-				_StaticJobDefJobField.SetValue(genCtx.JobDefinitionInstance, newJob);
+        private static bool GeneratePaxJob(PaxJobContext genCtx)
+        {
+            try
+            {
+                var genMode = GetPaxJobGenerationMode(genCtx);
+                var chainData = (StationsChainData)CreateExpressStationsChainData(genCtx.OriginStation.ID, genCtx.DestinationRouteTracks.Select(rt => (GetRouteTrackTrackField(rt)).ID.yardId).ToArray()).Value;
+                var superTask = BuildUpTasks(genCtx, genMode);
+                Job newJob = new(superTask, genCtx.JobType, genCtx.TimeLimit, genCtx.InitialWage, chainData, genCtx.ForcedJobId, genCtx.RequiredLicenses);
+                _StaticJobDefJobField.SetValue(genCtx.JobDefinitionInstance, newJob);
 
-				if (genCtx.FromSave) Main._modEntry.Logger.Log($"Loading job {genCtx.ForcedJobId} from save with gen mode {genMode}");
+                if (genCtx.FromSave) Main._modEntry.Logger.Log($"Loading job {genCtx.ForcedJobId} from save with gen mode {genMode}");
 
-				if (genMode == PaxJobGenerationMode.Empty_OnPlatform || genMode == PaxJobGenerationMode.Empty_OffPlatform || genMode == PaxJobGenerationMode.Empty_Taken)
-				{
-					var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.StartingRouteTrack)).Value;
-					_PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
-				}
+                if (genMode == PaxJobGenerationMode.Empty_OnPlatform || genMode == PaxJobGenerationMode.Empty_OffPlatform || genMode == PaxJobGenerationMode.Empty_Taken)
+                {
+                    var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.StartingRouteTrack)).Value;
+                    _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
+                }
 
-				for (int i = 0; i < genCtx.DestinationRouteTracks.Count - 1; i++)
-				{
-					var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks[i])).Value;
-					newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
-				}
+                for (int i = 0; i < genCtx.DestinationRouteTracks.Count - 1; i++)
+                {
+                    var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks[i])).Value;
+                    newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
+                }
 
-				var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks.Last())).Value;
-				newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
+                var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(genCtx.DestinationRouteTracks.Last())).Value;
+                newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
 
-				genCtx.OriginStation.AddJobToStation(genCtx.BaseJobDefinition.job);
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Main._modEntry.Logger.LogException("Failed to generate pax job due to: ", ex);
-				return false;
-			}
-		}
+                genCtx.OriginStation.AddJobToStation(genCtx.BaseJobDefinition.job);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Main._modEntry.Logger.LogException("Failed to generate pax job due to: ", ex);
+                return false;
+            }
+        }
 
-		private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
-		{
-			jobChainControllers = new();
+        private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
+        {
+            jobChainControllers = new();
 
-			if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
+            if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
 
-			if (IsPassengerStation(station.stationInfo.YardID))
-			{
-				var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
+            if (IsPassengerStation(station.stationInfo.YardID))
+            {
+                var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
 
-				if (!fittingPlatforms.Any())
-				{
-					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-					return;
-				}
+                if (!fittingPlatforms.Any())
+                {
+                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+                    return;
+                }
 
-				JobType jobType = PickPassengerJobType(trainCars.Count);
-				if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal;
-				jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
-				return;
-			}
-			else
-			{
-				Main._modEntry.Logger.Log($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get unloaded");
-				//generate FH job to random pax station: use already existing mod logic elswhere
-				StationController viableDestStation = FindDestinationStation(station, trainCars);
-				if (viableDestStation != null)
-				{
-					Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
-					JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
-					if (transportJobChainController != null)
-					{
-						transportJobChainController.FinalizeSetupAndGenerateFirstJob();
-						jobChainControllers.Add(transportJobChainController);
-						return;
-					}
-				}
-				else
-				{
-					Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a FH to any pax station, attempting splitting");
-					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-					return;
-				}
-			}
+                JobType jobType = PickPassengerJobType(trainCars.Count);
+                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal;
+                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
+                return;
+            }
+            else
+            {
+                Main._modEntry.Logger.Log($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get unloaded");
+                //generate FH job to random pax station: use already existing mod logic elswhere
+                StationController viableDestStation = FindDestinationStation(station, trainCars);
+                if (viableDestStation != null)
+                {
+                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
+                    JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
+                    if (transportJobChainController != null)
+                    {
+                        transportJobChainController.FinalizeSetupAndGenerateFirstJob();
+                        jobChainControllers.Add(transportJobChainController);
+                        return;
+                    }
+                }
+                else
+                {
+                    Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a FH to any pax station, attempting splitting");
+                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+                    return;
+                }
+            }
 
-			Main._modEntry.Logger.Error("[HandleLoadedPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
-		}
+            Main._modEntry.Logger.Error("[HandleLoadedPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+        }
 
-		private static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
-		{
-			jobChainControllers = new();
+        private static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
+        {
+            jobChainControllers = new();
 
-			if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
+            if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
 
-			if (IsPassengerStation(station.stationInfo.YardID))
-			{
-				var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
+            if (IsPassengerStation(station.stationInfo.YardID))
+            {
+                var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
 
-				if (!fittingPlatforms.Any())
-				{
-					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-					return;
-				}
+                if (!fittingPlatforms.Any())
+                {
+                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+                    return;
+                }
 
-				JobType jobType = PickPassengerJobType(trainCars.Count);
-				if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes <-- do this dynamically from PaxJobs routes list?
-				jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
-				return;
-			}
-			else
-			{
-				Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned a pax job");
-				//generate LH job to random pax station: use already existing mod logic elswhere
-				StationController viableDestStation = FindDestinationStation(station, trainCars);
-				if (viableDestStation != null)
-				{
-					Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
-					JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
-					if (emptyHaulJobChainController != null)
-					{
-						emptyHaulJobChainController.FinalizeSetupAndGenerateFirstJob();
-						jobChainControllers.Add(emptyHaulJobChainController);
-						return;
-					}
-				}
-				else
-				{
-					Main._modEntry.Logger.Error($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
-					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-					return;
-				}
-			}
+                JobType jobType = PickPassengerJobType(trainCars.Count);
+                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes <-- do this dynamically from PaxJobs routes list?
+                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
+                return;
+            }
+            else
+            {
+                Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned a pax job");
+                //generate LH job to random pax station: use already existing mod logic elswhere
+                StationController viableDestStation = FindDestinationStation(station, trainCars);
+                if (viableDestStation != null)
+                {
+                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
+                    JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
+                    if (emptyHaulJobChainController != null)
+                    {
+                        emptyHaulJobChainController.FinalizeSetupAndGenerateFirstJob();
+                        jobChainControllers.Add(emptyHaulJobChainController);
+                        return;
+                    }
+                }
+                else
+                {
+                    Main._modEntry.Logger.Error($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
+                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+                    return;
+                }
+            }
 
-			Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
-		}
+            Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+        }
 
 
-		#region PaxJobs Patches
+        #region PaxJobs Patches
 
 #pragma warning disable IDE0060 // Remove unused parameter
 
-		private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
-		{
-			var instanceBase = (StaticJobDefinition)__instance;
-			List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
-			RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
-			if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
-			var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
+        private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
+        {
+            var instanceBase = (StaticJobDefinition)__instance;
+            List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+            RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
+            if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
 
-			var definitionGO = ((MonoBehaviour)__instance).gameObject;
-			bool modified = definitionGO.GetComponent<PaxJobModifiedFlag>() != null;
-			var takenFlag = definitionGO.GetComponent<PaxJobJobTakenFlag>();
-			JobChainSaveData chainSaveData = takenFlag?.jobChainSaveData;
-			bool taken = takenFlag != null;
+            var definitionGO = ((MonoBehaviour)__instance).gameObject;
+            bool modified = definitionGO.GetComponent<PaxJobModifiedFlag>() != null;
+            var takenFlag = definitionGO.GetComponent<PaxJobJobTakenFlag>();
+            JobChainSaveData chainSaveData = takenFlag?.jobChainSaveData;
+            bool taken = takenFlag != null;
 
-			if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
-			{
-				Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
-				return false;
-			}
-			bool loaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
+            if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
+            {
+                Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
+                return false;
+            }
+            bool loaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
 
-			PaxJobContext genCtx = new(__instance, chainSaveData, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, cars, startingRouteTrack, destinationTracks, taken, modified);
+            PaxJobContext genCtx = new(__instance, chainSaveData, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, cars, startingRouteTrack, destinationTracks, taken, modified);
 
-			return !GeneratePaxJob(genCtx);
-		}
+            return !GeneratePaxJob(genCtx);
+        }
 
-		private static void LoadPassengerChain_Postfix(object __result, object[] __args)
-		{
-			if (__result != null)
-			{
-				Main._modEntry.Logger.Log("Flagg adding postfix runs");
-				var jcc = (JobChainController)__result;
-				var chainSaveData = (JobChainSaveData)__args[0];
+        private static void LoadPassengerChain_Postfix(object __result, object[] __args)
+        {
+            if (__result != null)
+            {
+                Main._modEntry.Logger.Log("Flagg adding postfix runs");
+                var jcc = (JobChainController)__result;
+                var chainSaveData = (JobChainSaveData)__args[0];
 
-				if (chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0) return;
+                if (chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0) return;
 
-				if (chainSaveData.jobTaken)
-				{
-					Main._modEntry.Logger.Log($"Adding 'JobTaken' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
-					var flag = jcc.jobChainGO.AddComponent<PaxJobJobTakenFlag>();
-					flag.jobChainSaveData = chainSaveData;
-				}
+                if (chainSaveData.jobTaken)
+                {
+                    Main._modEntry.Logger.Log($"Adding 'JobTaken' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
+                    var flag = jcc.jobChainGO.AddComponent<PaxJobJobTakenFlag>();
+                    flag.jobChainSaveData = chainSaveData;
+                }
 
 
-				var headTask = chainSaveData.currentJobTaskData[0];
-				if (headTask.type != TaskType.Sequential) return;
+                var headTask = chainSaveData.currentJobTaskData[0];
+                if (headTask.type != TaskType.Sequential) return;
 
-				if (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0)
-				{
-					var firstChild = complexData.tasksData[0];
-					if (firstChild.type == TaskType.Transport)
-					{
-						Main._modEntry.Logger.Log($"Adding 'modified' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
-						jcc.jobChainGO.AddComponent<PaxJobModifiedFlag>();
-					}
-				}
-			}
-		}
+                if (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0)
+                {
+                    var firstChild = complexData.tasksData[0];
+                    if (firstChild.type == TaskType.Transport)
+                    {
+                        Main._modEntry.Logger.Log($"Adding 'modified' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
+                        jcc.jobChainGO.AddComponent<PaxJobModifiedFlag>();
+                    }
+                }
+            }
+        }
 
-		private static bool StartGenerationAsync_Prefix(object __instance)
-		{
-			StationController generatingStation = (StationController)_PaxJGeneratorStContField.GetValue(__instance);
-			if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(generatingStation) && !OverrideSpawnFlagForPaxJ)
-			{
-				Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} has already spawned cars, skipping passanger jobs with new cars generation");
-				return false;
-			}
-			else
-			{
-				Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} is generating passanger jobs with cars");
-				OverrideSpawnFlagForPaxJ = false;
-				return true;
-			}
-		}
+        private static bool StartGenerationAsync_Prefix(object __instance)
+        {
+            StationController generatingStation = (StationController)_PaxJGeneratorStContField.GetValue(__instance);
+            if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(generatingStation) && !OverrideSpawnFlagForPaxJ)
+            {
+                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} has already spawned cars, skipping passanger jobs with new cars generation");
+                return false;
+            }
+            else
+            {
+                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} is generating passanger jobs with cars");
+                OverrideSpawnFlagForPaxJ = false;
+                return true;
+            }
+        }
 
-		private static bool ExtractPassengerJobData_Prefix(ref Job_data job)
-		{
-			//adding a dummy load task data if there is none in origin station
+        //this is very hackish, we can´t patch the constructor for PassengerJobs.Generation.RouteNode which demands unused tracks, so we patch that method to ignore it but only when the call came from us
+        private static bool GetUnusedRouteTracks_Prefix(IEnumerable tracks, ref IEnumerable __result)
+        {
+            if (!BypassUnusedTracksFilter) return true;
 
-			bool result = FilterJobDataForModPaxJob(ref job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit);
-			if (exit) return result;
+            var validTracks = new List<object>();
+            foreach (object rtrack in tracks)
+            {
+                RouteTrackRef track = new(rtrack);
+                if (IsRouteTrackASegment(track))
+                {
+                    validTracks.Add(rtrack);
+                }
+                else if (YardTracksOrganizer.Instance.GetReservedSpace(GetRouteTrackTrackField(track)) <= _YTO_ReserveThreshold)
+                {
+                    validTracks.Add(rtrack);
+                }
+            }
 
-			Task_data[] newNestedTasks = null;
-			bool loadingFound = false;
-			foreach (var taskData in taskSequence.nestedTasks)
-			{
-				if (taskData.instanceTaskType != TaskType.Warehouse) continue;
-				if (taskData.warehouseTaskType == WarehouseTaskType.Loading)
-				{
-					loadingFound = true;
-					continue;
-				}
-				if (taskData.warehouseTaskType == WarehouseTaskType.Unloading && !loadingFound)
-				{
-					//var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(CarTrackAssignment.TrainCarsByGuid(taskData.cars.Select(c => c.ID)));
-					var carsTrack = firstNestedTask.startTrackID;
-					if (carsTrack == null) break;
+            Array typedArray = Array.CreateInstance(_RouteTrack, validTracks.Count);
+            for (int i = 0; i < validTracks.Count; i++)
+            {
+                typedArray.SetValue(validTracks[i], i);
+            }
+            __result = (IEnumerable)typedArray;
+            return false;
+        }
 
-					var destTrack = GetRouteTrackTrackField(GetPlatforms(GetStationData(carsTrack.yardId)).First());
-					var taskList = taskSequence.nestedTasks.ToList();
-					taskList.Insert(1, new Task_data(TaskType.Warehouse, TaskType.Warehouse, TaskState.InProgress, 0, 0, taskData.cars, carsTrack, destTrack.ID, WarehouseTaskType.None, new List<CargoType>(), 0, false, false, Array.Empty<Task_data>()));
-					newNestedTasks = taskList.ToArray();
-					break;
-				}
-			}
+        private static void OnLastJobInChainCompletedReverse(JobChainController instance, Job lastJobInChain)
+        {
+            throw new NotImplementedException();
+        }
 
-			if (newNestedTasks?.Length > 1) taskSequence.nestedTasks = newNestedTasks;
-			job.tasksData[0] = taskSequence;
-			return true;
-		}
+        private static bool OnLastJobInChainCompletedOverride_Prefix(JobChainController __instance, Job lastJobInChain)
+        {
+            Main._modEntry.Logger.Log("Last pax job in chain completed");
+            PersistentJobsMod.HarmonyPatches.JobChainControllers.JobChainController_OnLastJobInChainCompleted_Patch.DecideForConsistAfterJobChainCompletion(__instance, __instance.jobChain, lastJobInChain);
+            OnLastJobInChainCompletedReverse(__instance, lastJobInChain);
+            return false;
+        }
 
-		private static bool CreateLoadTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
-		{
-			//skip creation of load page for our modified jobs (starting with transport) that are from loaded cars
+        private static bool ExtractPassengerJobData_Prefix(ref Job_data job)
+        {
+            //adding a dummy load task data if there is none in origin station
 
-			PassengerJobDataRef jobData = new(__args[0]);
-			object initialStopInfo = __args[1];
-			if (_InitialStopField.GetValue(jobData.Value) == initialStopInfo)
-			{
-				var baseJobData = ((TransportJobData)jobData.Value).job;
-				bool result = FilterJobDataForModPaxJob(ref baseJobData, out _, out Task_data firstNestedTask, out bool exit);
-				if (exit) return result;
+            bool result = FilterJobDataForModPaxJob(ref job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit);
+            if (exit) return result;
 
-				if (firstNestedTask.startTrackID == firstNestedTask.destinationTrackID)
-				{
-					//from context we now know (hopefully?) that the cars were loaded 
-					__result = null;
-					return false;
-				}
-			}
-			return true;
-		}
+            Task_data[] newNestedTasks = null;
+            bool loadingFound = false;
+            foreach (var taskData in taskSequence.nestedTasks)
+            {
+                if (taskData.instanceTaskType != _CityLoadingTaskType) continue;
+                if (taskData.warehouseTaskType == WarehouseTaskType.Loading)
+                {
+                    loadingFound = true;
+                    continue;
+                }
+                if (taskData.warehouseTaskType == WarehouseTaskType.Unloading && !loadingFound)
+                {
+                    var carsTrack = firstNestedTask.startTrackID;
+                    if (carsTrack == null) break;
 
-		private static bool CreateCoupleTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
-		{
-			PassengerJobDataRef jobData = new(__args[0]);
-			var baseJobData = (TransportJobData)(jobData.Value);
-			var station = baseJobData.job.chainOriginStationInfo;
-			var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
-			__result = (TemplatePaperData)_CreateCoupleTaskPaperData.Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
-			return false;
-		}
+                    var destTrack = GetRouteTrackTrackField(GetPlatforms(GetStationData(carsTrack.yardId)).First());
+                    var taskList = taskSequence.nestedTasks.ToList();
+                    taskList.Insert(1, new Task_data(_CityLoadingTaskType, _CityLoadingTaskType, TaskState.InProgress, 0, 0, taskData.cars, carsTrack, destTrack.ID, WarehouseTaskType.None, new List<CargoType>(), 0, false, false, Array.Empty<Task_data>()));
+                    newNestedTasks = taskList.ToArray();
+                    break;
+                }
+            }
 
-		private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)
-		{
-			__result = __result.Where(t => t != null).ToList();
-		}
+            if (newNestedTasks?.Length > 1) taskSequence.nestedTasks = newNestedTasks;
+            job.tasksData[0] = taskSequence;
+            return true;
+        }
+
+        private static bool CreateLoadTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+        {
+            //skip creation of load page for our modified jobs (starting with transport) that are from loaded cars
+
+            PassengerJobDataRef jobData = new(__args[0]);
+            object initialStopInfo = __args[1];
+            if (_InitialStopField.GetValue(jobData.Value) == initialStopInfo)
+            {
+                var baseJobData = ((TransportJobData)jobData.Value).job;
+                bool result = FilterJobDataForModPaxJob(ref baseJobData, out _, out Task_data firstNestedTask, out bool exit);
+                if (exit) return result;
+
+                if (firstNestedTask.startTrackID == firstNestedTask.destinationTrackID)
+                {
+                    //from context we now know (hopefully?) that the cars were loaded 
+                    __result = null;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static bool CreateCoupleTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+        {
+            PassengerJobDataRef jobData = new(__args[0]);
+            var baseJobData = (TransportJobData)(jobData.Value);
+            var station = baseJobData.job.chainOriginStationInfo;
+            var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
+            __result = (TemplatePaperData)_CreateCoupleTaskPaperData.Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
+            return false;
+        }
+
+        private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)
+        {
+            __result = __result.Where(t => t != null).ToList();
+        }
 
 #pragma warning restore IDE0060 // Remove unused parameter
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -37,972 +37,1066 @@ using PassengerJobDataRef = PersistentJobsMod.Utilities.ReflectionUtilities.Fore
 
 namespace PersistentJobsMod.ModInteraction
 {
-    public static class PaxJobsCompat
-    {
-        #region Reflection setup
-        private static Assembly asm;
+	public static class PaxJobsCompat
+	{
+		#region Reflection setup
+		private static Assembly asm;
 
-        private static Type _RouteManager;
-        private static Type _ConsistManager;
-        private static Type _RouteTrack;
-        private static Type _PassConsistInfo;
-        private static Type _PassengerJobGenerator;
-        private static Type _IPassDestination;
-        private static Type _PassJobType;
-        private static Type _PassengerChainController;
-        private static Type _PassengerHaulJobDefinition;
-        private static Type _RouteResult;
-        private static Type _RouteType;
-        private static Type _ExpressStationsChainData;
-        private static Type _PlatformController;
-        private static Type _BookletUtility;
-        private static Type _BookletCreator_JobPatch;
-        private static Type _PassengerJobData;
-        private static Type _PassStopInfo;
+		private static Type _RouteManager;
+		private static Type _ConsistManager;
+		private static Type _RouteTrack;
+		private static Type _PassConsistInfo;
+		private static Type _PassengerJobGenerator;
+		private static Type _IPassDestination;
+		private static Type _PassJobType;
+		private static Type _PassengerChainController;
+		private static Type _PassengerHaulJobDefinition;
+		private static Type _RouteResult;
+		private static Type _RouteType;
+		private static Type _ExpressStationsChainData;
+		private static Type _PlatformController;
+		private static Type _BookletUtility;
+		private static Type _BookletCreator_JobPatch;
+		private static Type _PassengerJobData;
+		private static Type _PassStopInfo;
+		private static Type _ExpressJobDefinitionData;
+		private static Type _JobSaveManagerPatch;
+		private static Type _PassengerChainSaveData;
 
-        private static ConstructorInfo _RouteTrackCtor;
-        private static ConstructorInfo _PassConsistInfoCtor;
-        private static ConstructorInfo _PassengerJccCtor;
-        private static ConstructorInfo _ExpressStChainDataCtor;
+		private static ConstructorInfo _RouteTrackCtor;
+		private static ConstructorInfo _PassConsistInfoCtor;
+		private static ConstructorInfo _PassengerJccCtor;
+		private static ConstructorInfo _ExpressStChainDataCtor;
 
-        private static MethodInfo _TryGetInstance;
-        private static MethodInfo _GenerateJob;
-        private static MethodInfo _GetPassengerCars;
-        private static MethodInfo _IsPassengerStation;
-        private static MethodInfo _GetStationData;
-        private static MethodInfo _GetRouteTrackById;
-        private static MethodInfo _GetPlatforms;
-        private static MethodInfo _PHJD_GenerateJob;
-        private static MethodInfo _GetRoute;
-        private static MethodInfo _GetRouteType;
-        private static MethodInfo _GetJobPaymentData;
-        private static MethodInfo _GetTotalHaulDistance;
-        private static MethodInfo _PopulateExpressJobExistingCars;
-        private static MethodInfo _PaxJGeneratorStartGenerationAsync;
-        private static MethodInfo _PHJD_CreateBoardingTask;
-        private static MethodInfo _PHJD_CreateTransportTask;
-        private static MethodInfo _PlatformControllerForTrack;
-        private static MethodInfo _PlatformRegisterOutgoingJob;
-        private static MethodInfo _PlatformRegisterIncomingJob;
-        private static MethodInfo _ExtractPassengerJobData;
-        private static MethodInfo _GetBookletTemplateData;
-        private static MethodInfo _CreateLoadTaskPage;
-        private static MethodInfo _CreateCoupleTaskPage;
+		private static MethodInfo _TryGetInstance;
+		private static MethodInfo _GenerateJob;
+		private static MethodInfo _GetPassengerCars;
+		private static MethodInfo _IsPassengerStation;
+		private static MethodInfo _GetStationData;
+		private static MethodInfo _GetRouteTrackById;
+		private static MethodInfo _GetPlatforms;
+		private static MethodInfo _PHJD_GenerateJob;
+		private static MethodInfo _GetRoute;
+		private static MethodInfo _GetRouteType;
+		private static MethodInfo _GetJobPaymentData;
+		private static MethodInfo _GetTotalHaulDistance;
+		private static MethodInfo _PopulateExpressJobExistingCars;
+		private static MethodInfo _PaxJGeneratorStartGenerationAsync;
+		private static MethodInfo _PHJD_CreateBoardingTask;
+		private static MethodInfo _PHJD_CreateTransportTask;
+		private static MethodInfo _PlatformControllerForTrack;
+		private static MethodInfo _PlatformRegisterOutgoingJob;
+		private static MethodInfo _PlatformRegisterIncomingJob;
+		private static MethodInfo _ExtractPassengerJobData;
+		private static MethodInfo _GetBookletTemplateData;
+		private static MethodInfo _CreateLoadTaskPage;
+		private static MethodInfo _CreateCoupleTaskPage;
+		private static MethodInfo _LoadPassengerChain;
 
-        private static PropertyInfo _AllTracksProperty;
-        private static PropertyInfo _RouteTrackLengthProp;
-        private static PropertyInfo _TrainCarsToTransportProp;
-        private static PropertyInfo _PaxStYardIdProperty;
-        private static PropertyInfo _RTPlatformIdProp;
+		private static PropertyInfo _AllTracksProperty;
+		private static PropertyInfo _RouteTrackLengthProp;
+		private static PropertyInfo _TrainCarsToTransportProp;
+		private static PropertyInfo _PaxStYardIdProperty;
+		private static PropertyInfo _RTPlatformIdProp;
 
-        private static FieldInfo _RouteTrackTrackField;
-        private static FieldInfo _StartingTrackField;
-        private static FieldInfo _DestinationTracksField;
-        private static FieldInfo _TaskStartingTrackField;
-        private static FieldInfo _RouteResultTracksField;
-        private static FieldInfo _RouteTrackStationField;
-        private static FieldInfo _PaxJGeneratorStContField;
-        private static FieldInfo _PHJD_RouteTypeField;
-        private static FieldInfo _StaticJobDefJobField;
-        private static FieldInfo _InitialStopField;
+		private static FieldInfo _RouteTrackTrackField;
+		private static FieldInfo _StartingTrackField;
+		private static FieldInfo _DestinationTracksField;
+		private static FieldInfo _TaskStartingTrackField;
+		private static FieldInfo _RouteResultTracksField;
+		private static FieldInfo _RouteTrackStationField;
+		private static FieldInfo _PaxJGeneratorStContField;
+		private static FieldInfo _PHJD_RouteTypeField;
+		private static FieldInfo _StaticJobDefJobField;
+		private static FieldInfo _InitialStopField;
 
-        private static Random _Random;
+		private static Random _Random;
 
-        private static JobType _PassengerExpress;
-        private static JobType _PassengerLocal;
+		private static JobType _PassengerExpress;
+		private static JobType _PassengerLocal;
 
-        private static object _RouteTypeExpress;
-        private static object _RouteTypeLocal;
+		private static object _RouteTypeExpress;
+		private static object _RouteTypeLocal;
 
-        //private static UnityEngine.Object[] _AllPlatformControllers;
+		//private static UnityEngine.Object[] _AllPlatformControllers;
 
-        public static bool Initialize()
+		public static bool Initialize()
+		{
+			try
+			{
+				asm = Main.PaxJobs.Assembly;
+
+				_RouteManager = CompatAccess.Type("PassengerJobs.Generation.RouteManager");
+				_ConsistManager = CompatAccess.Type("PassengerJobs.Generation.ConsistManager");
+				_RouteTrack = CompatAccess.Type("PassengerJobs.Generation.RouteTrack");
+				_PassConsistInfo = CompatAccess.Type("PassengerJobs.Generation.PassConsistInfo");
+				_PassengerJobGenerator = CompatAccess.Type("PassengerJobs.Generation.PassengerJobGenerator");
+				_IPassDestination = CompatAccess.Type("PassengerJobs.Generation.IPassDestination");
+				_PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
+				_PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
+				_PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
+				_RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
+				_RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
+				_ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
+				_PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
+				_BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
+				_BookletCreator_JobPatch = CompatAccess.Type("PassengerJobs.Patches.BookletCreator_JobPatch");
+				_PassengerJobData = CompatAccess.Type("PassengerJobs.PassengerJobData");
+				_PassStopInfo = CompatAccess.Type("PassengerJobs.PassStopInfo");
+				_ExpressJobDefinitionData = CompatAccess.Type("PassengerJobs.Generation.ExpressJobDefinitionData");
+				_JobSaveManagerPatch = CompatAccess.Type("PassengerJobs.Patches.JobSaveManagerPatch");
+				_PassengerChainSaveData = CompatAccess.Type("PassengerJobs.Generation.PassengerChainSaveData");
+
+				_TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
+				_GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
+				_GetPassengerCars = CompatAccess.Method(_ConsistManager, "GetPassengerCars");
+				_IsPassengerStation = CompatAccess.Method(_RouteManager, "IsPassengerStation");
+				_GetStationData = CompatAccess.Method(_RouteManager, "GetStationData");
+				_GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
+				_GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
+				_PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
+				_GetRoute = CompatAccess.Method(_RouteManager, "GetRoute");
+				_GetRouteType = CompatAccess.Method(_PassJobType, "GetRouteType");
+				_GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
+				_GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
+				_PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
+				_PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
+				_PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack, typeof(float), typeof(bool), typeof(bool) });
+				_PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track) });
+				_PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] { typeof(string) });
+				_PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool) });
+				_PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool) });
+				_ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
+				_GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
+				_CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
+				_CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
+				_LoadPassengerChain = CompatAccess.Method(_JobSaveManagerPatch, "LoadPassengerChain", new[] { _PassengerChainSaveData });
+
+				_AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
+				_RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
+				_TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
+				_PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
+				_RTPlatformIdProp = CompatAccess.Property(_RouteTrack, "PlatformID");
+
+				_RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
+				_StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
+				_DestinationTracksField = CompatAccess.Field(_PassengerHaulJobDefinition, "DestinationTracks");
+				_TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
+				_RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
+				_RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
+				_PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
+				_PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
+				_StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
+				_InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
+
+				_RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
+				_PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
+				_PassengerJccCtor = CompatAccess.Ctor(_PassengerChainController, new[] { typeof(GameObject) });
+				_ExpressStChainDataCtor = CompatAccess.Ctor(_ExpressStationsChainData, new[] { typeof(string), Type.GetType("System.String[]") });
+
+				_Random = new Random();
+
+				_PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
+				_PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
+
+				_RouteTypeExpress = Enum.Parse(_RouteType, "Express");
+				_RouteTypeLocal = Enum.Parse(_RouteType, "Local");
+
+				//_AllPlatformControllers ??= UnityEngine.Object.FindObjectsOfType(_PlatformController) ?? throw new KeyNotFoundException("No platform controllesr present, this shouldn´t happen");
+
+				PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
+				PatchPostfix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Postfix));
+
+				PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
+
+				PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
+
+				PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
+
+				PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
+
+				PatchPrefix(_CreateCoupleTaskPage, typeof(PaxJobsCompat), nameof(CreateCoupleTaskPage_Prefix));
+
+				PatchPostfix(_LoadPassengerChain, typeof(PaxJobsCompat), nameof(LoadPassengerChain_Postfix));
+
+			}
+			catch (Exception e)
+			{
+				Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods", e);
+				return false;
+			}
+
+			return true;
+		}
+
+		public class Tags
+		{
+			public sealed class RouteManager { };
+			public sealed class ConsistManager { };
+			public sealed class RouteTrack { };
+			public sealed class PassConsistInfo { };
+			public sealed class PassengerJobGenerator { };
+			public sealed class IPassDestination { };
+			public sealed class PassJobType { };
+			public sealed class PassengerChainController { };
+			public sealed class PassengerHaulJobDefinition { };
+			public sealed class RouteResult { };
+			public sealed class RouteType { };
+			public sealed class ExpressStationsChainData { };
+			public sealed class PlatformController { };
+			public sealed class PassengerJobData { };
+
+			public class PaxJobModifiedFlag : MonoBehaviour { }
+			public class PaxJobJobTakenFlag : MonoBehaviour { }
+		}
+		#endregion
+
+		public static bool OverrideSpawnFlagForPaxJ = false;
+
+		private static bool TryGetGenerator(string yardId, out object generator)
+		{
+			generator = null;
+			var args = new object[] { yardId, null };
+			if (!(bool)_TryGetInstance.Invoke(null, args))
+			{
+				Main._modEntry.Logger.Error($"Couldn´t get instance of PaxJobsGenerator for {yardId}");
+				return false;
+			}
+
+			generator = args[1];
+			return generator != null;
+		}
+
+		public static void PaxJobsOrigGenJobsInStation(string yardId)
+		{
+			if (!TryGetGenerator(yardId, out object generator))
+			{
+				Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
+				return;
+			}
+			_PaxJGeneratorStartGenerationAsync.Invoke(generator, new object[0]);
+			Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
+		}
+
+		//public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
+		private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
+		{
+			passengerChainController = null;
+			if (!AStartGameData.carsAndJobsLoadingFinished) return false;
+			if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
+			Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
+
+			/*if (!TryGetGenerator(yardId, out object generator))
+			{
+				Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
+				return false;
+			}
+
+			passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });*/
+
+			if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
+			{
+				Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
+				return false;
+			}
+
+			if (passengerChainController == null || passengerChainController.currentJobInChain == null) Main._modEntry.Logger.Error("JobChainController or its job is null, this shouldn´t happen!"); ;
+			return passengerChainController != null;
+		}
+
+		private static RouteTrackRef CreateRouteTrack(IPassDestinationRef IPassDestination, Track terminalTrack) => new(_RouteTrackCtor.Invoke(new object[] { IPassDestination.Value, terminalTrack }));
+
+		private static object CreatePassConsistInfo(RouteTrackRef routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack.Value, cars });
+
+		private static PassengerChainControllerRef CreatePassJcc(GameObject jobChainGameObject) => new(_PassengerJccCtor.Invoke(new object[] { jobChainGameObject }));
+
+		private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
+
+		public static bool IsPaxJobDefinition(StaticJobDefinition jobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)
+		{
+			passengerHaulJobDefinition = new(null);
+			if (jobDefinition == null) return false;
+			var job = jobDefinition.job;
+			if (job == null) return false;
+			bool correctType = (job.jobType == _PassengerExpress || job.jobType == _PassengerLocal);
+			bool correctDef = _PassengerHaulJobDefinition.IsInstanceOfType(jobDefinition);
+			passengerHaulJobDefinition = new(jobDefinition);
+			return correctType && correctDef;
+		}
+
+		public static bool IsPaxCars(TrainCar car)
+		{
+			var carLiveries = (IEnumerable<TrainCarLivery>)_GetPassengerCars.Invoke(null, null);
+			return carLiveries != null && car.carLivery != null && carLiveries.Contains(car.carLivery);
+		}
+
+		public static float GetConsistLength(List<TrainCar> trainCars)
+		{
+			return CarSpawner.Instance.GetTotalCarsLength(
+				TrainCar.ExtractLogicCars(trainCars),
+				true
+			);
+		}
+
+		private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
+
+		public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
+
+		private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
+
+		private static RouteResultRef GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => new(_GetRoute?.Invoke(null, new object[] { GetStationData(yardId).Value, routeType, existingDests, minLength }));
+
+		private static RouteTrackRef GetRouteTrackByIdOrNull(string trackFullDisplayId)
+		{
+			RouteTrackRef routeTrack = new(_GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId }));
+			if (routeTrack.Value is null) return new(null);
+			Track trackField = GetRouteTrackTrackField(routeTrack);
+			if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return new(null);
+			return routeTrack;
+		}
+
+		private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId).Value)).ToList();
+
+		private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
+
+		private static IEnumerable<RouteTrackRef> GetPlatforms(IPassDestinationRef stationData, bool onlyTerminusTracks = false)
+		{
+			var result = _GetPlatforms.Invoke(stationData.Value, new object[] { onlyTerminusTracks });
+			if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return new(item);
+		}
+
+		private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
+
+		private static Track GetRouteTrackTrackField(RouteTrackRef routeTrack)
+		{
+			if (routeTrack.Value == null) return null;
+			var track = (Track)_RouteTrackTrackField.GetValue(routeTrack.Value);
+			if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
+			return track;
+		}
+
+		private static IPassDestinationRef GetRouteTrackStationField(RouteTrackRef routeTrack)
+		{
+			if (routeTrack.Value == null) return new(null);
+			var iPassDest = _RouteTrackStationField.GetValue(routeTrack.Value);
+			if (iPassDest == null) return new(null);
+			return new(iPassDest);
+		}
+
+		//private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
+		private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
+
+		private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
+
+		private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
+
+		private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
+
+		private static bool CanFitInStation(IPassDestinationRef stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
+
+		private static RouteTypeRef GetRouteType(JobType type) => new(_GetRouteType.Invoke(null, new object[] { type }));
+
+		private static object GetRouteResultTracksArray(RouteResultRef routeResult) => _RouteResultTracksField.GetValue(routeResult.Value);
+
+		private static float GetTotalHaulDistance(StationController startStation, Array destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
+
+		private static JobType PickPassengerJobType(int carCount)
+		{
+			if (carCount <= 4)
+				return (JobType)_Random.Next(101, 103); // Express or Local
+
+			return _PassengerExpress;
+		}
+
+		private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
+
+		private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] { platform.Value, totalCapacity, loading, isFinal }));
+
+		private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack });
+
+		private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
+		{
+			if (!fittingPlatforms.Any()) return new(null);
+
+			if (currentTrack != null)
+			{
+				string currentTrackId = currentTrack.ID.FullDisplayID;
+				var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
+				{
+					var track = GetRouteTrackTrackField(rt);
+					return track != null && track.ID.FullDisplayID == currentTrackId;
+				});
+
+				if (matchingPlatform.Value != null)
+				{
+					Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
+					return matchingPlatform;
+				}
+				Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random free platform");
+			}
+			else Main._modEntry.Logger.Log("Could not determine current track, selecting random free platform");
+
+			return fittingPlatforms.OrderByDescending(p =>
+			{
+				var track = GetRouteTrackTrackField(p) ?? new Track(0);
+				return track.length - track.OccupiedLength;
+			}).FirstOrDefault();
+		}
+
+		private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<RouteTrackRef> fittingPlatforms, JobType jobType)
+		{
+			List<JobChainController> result = new();
+			if (trainCars.Count() > 20)
+			{
+				result.AddRange(HandleSplitOrFail(trainCars, station));
+				return result;
+			}
+
+			Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+			var preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
+			if (preferredRouteTrack.Value == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
+			{
+				Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
+				result.AddRange(HandleSplitOrFail(trainCars, station));
+				return result;
+			}
+
+			if (!fittingPlatforms.Contains(preferredRouteTrack))
+			{
+				Main._modEntry.Logger.Error("Selected RouteTrack is not in fitting platforms list");
+				return result;
+			}
+
+			Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
+
+			//if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(cars)), out JobChainController passangerChainController))
+			if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
+			{
+				Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
+				result.Add(passangerChainController);
+				return result;
+			}
+
+			result.AddRange(HandleSplitOrFail(trainCars, station));
+			return result;
+		}
+
+		private static List<JobChainController> HandleSplitOrFail(List<TrainCar> trainCars, StationController station)
+		{
+			List<JobChainController> result = new();
+			if (trainCars.Count < 2)
+			{
+				Main._modEntry.Logger.Error($"Single pax car {trainCars.First().ID} cannot be reassigned");
+				return result;
+			}
+
+			var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(new List<IReadOnlyList<TrainCar>> { trainCars });
+			if (emptyConsecutiveTrainCarGroups.Any())
+			{
+				foreach (var emptyTrainCars in emptyConsecutiveTrainCarGroups)
+				{
+					Main._modEntry.Logger.Log($"Spilitting consist starting with car {emptyTrainCars.First().ID}");
+					var (first, second) = emptyTrainCars.SplitInHalf();
+					HandleEmptyPaxCars(first, station, out List<JobChainController> outJobChainControllers);
+					result.AddRange(outJobChainControllers);
+					HandleEmptyPaxCars(second, station, out outJobChainControllers);
+					result.AddRange(outJobChainControllers);
+				}
+			}
+
+			if (loadedConsecutiveTrainCarGroups.Any())
+			{
+				foreach (var loadedTrainCars in loadedConsecutiveTrainCarGroups)
+				{
+					Main._modEntry.Logger.Log($"Spilitting consist starting with car {loadedTrainCars.First().ID}");
+					var (first, second) = loadedTrainCars.SplitInHalf();
+					HandleLoadedPaxCars(first, station, out List<JobChainController> outJobChainControllers);
+					result.AddRange(outJobChainControllers);
+					HandleLoadedPaxCars(second, station, out outJobChainControllers);
+					result.AddRange(outJobChainControllers);
+				}
+			}
+
+			return result;
+		}
+
+		private static (List<IReadOnlyList<TrainCar>>, List<IReadOnlyList<TrainCar>>) SortCGIntoEmptyAndLoaded(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups)
+		{
+			var statusTrainCarGroups = paxConsecutiveTrainCarGroups.SelectMany(cars => cars.GroupConsecutiveBy(tc => GetTrainCarReassignStatus(tc))).ToList();
+			var emptyConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Empty).Select(s => s.Items).ToList();
+			var loadedConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Loaded).Select(s => s.Items).ToList();
+
+			Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+			Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
+			return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
+		}
+
+		private static void AddTransportTaskToTop(StaticJobDefinition staticPaxJobDefinition, Track currentTrack, Track destinatiionTrack, List<Car> cars)
+		{
+			if (staticPaxJobDefinition != null)
+			{
+				if (staticPaxJobDefinition.job == null)
+				{
+					Main._modEntry.Logger.Error("staticJobDefinition.job is null");
+					return;
+				}
+				var job = staticPaxJobDefinition.job;
+				Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
+				var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
+				if (headSequentialTask != null)
+				{
+					var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
+					newTransportTask.SetJobBelonging(job);
+					headSequentialTask.tasks.AddFirst(newTransportTask);
+				}
+				else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
+			}
+			else Main._modEntry.Logger.Error($"Couldn´t get job definition");
+
+		}
+
+		public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
+		{
+			List<JobChainController> result = new();
+			Main._modEntry.Logger.Log($"Reassigning passanger cars to jobs in station {station.logicStation.ID}");
+
+			EnsureTrainCarsAreConvertedToNonPlayerSpawned(FilterTrainCarGroups(paxConsecutiveTrainCarGroups).SelectMany(tcg => tcg).ToList());
+
+			var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(paxConsecutiveTrainCarGroups);
+			foreach (List<TrainCar> tcs in emptyConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+			{
+				HandleEmptyPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
+				result.AddRange(jobChainControllers);
+			}
+			foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
+			{
+				Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
+				//handling complicated - no inbuilt methods for job generation from already loaded cars
+
+				HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
+				result.AddRange(jobChainControllers);
+			}
+
+			return result;
+		}
+
+		public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
+		{
+			trainCarGroups.RemoveAll(trainCars =>
+			{
+				if (trainCars == null || trainCars.Count == 0)
+				{
+					Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid cars input thrown out");
+					return true;
+				}
+				if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
+
+				return trainCars.All(tc => tc.derailed);
+			});
+			return trainCarGroups;
+		}
+
+		private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
+		{
+			var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID).Value != null ? (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList()) : new List<Track>();
+			return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
+		}
+
+		private static List<RouteTrackRef> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
+		{
+			var stationData = GetStationData(station.stationInfo.YardID);
+			return stationData.Value == null ? new List<RouteTrackRef>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
+		}
+
+		private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
+
+		private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
+
+		private static bool FilterJobDataForModPaxJob(ref Job_data job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit)
+		{
+			firstNestedTask = null;
+			taskSequence = null;
+
+			if (job.tasksData == null || job.tasksData.Length == 0)
+			{
+				exit = true;
+				return false;
+			}
+
+			taskSequence = job.tasksData[0];
+			if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1)
+			{
+				exit = true;
+				return false;
+			}
+
+			firstNestedTask = taskSequence.nestedTasks[0];
+			if (firstNestedTask.instanceTaskType != TaskType.Transport)
+			{
+				exit = true;
+				return true;
+			}
+
+			exit = false;
+			return false;
+		}
+
+		private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
+		{
+			startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+			if (startingTrack == null)
+			{
+				Main._modEntry.Logger.Error("No starting track found");
+				return false;
+			}
+
+			if (startingTrack.ID.yardId != station.stationInfo.YardID)
+			{
+				Main._modEntry.Logger.Error("Station mismatch");
+				return false;
+			}
+			return true;
+		}
+
+		private static bool SetupAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
+		{
+			passengerChainController = null;
+			//object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
+			var currentDests = startingStation.logicStation.availableJobs
+				.Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
+				.Select(j => j.chainData.chainDestinationYardId);
+
+			var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType).Value, currentDests, GetConsistLength(trainCars));
+			if (destinations.Value == null) return false;
+
+			var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
+
+			if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+			var destinationTracks = rrTracksArray.Cast<object>().Select(o => new Foreign<RouteTrackRef>(o)).Select(rt => (Track)_RouteTrackTrackField.GetValue(rt.Value)).ToList();
+			var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(new RouteTrackRef(d))));
+
+			// create job chain controller
+			string destString = string.Join(" - ", destinationRouteTracksYardIDs);
+			var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
+			chainJobObject.transform.SetParent(startingStation.transform);
+			var chainController = (JobChainController)CreatePassJcc(chainJobObject).Value;
+
+			var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray()).Value;
+			PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
+
+			float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
+			float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false);
+			float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
+
+			chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
+
+			var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment).Value;
+			if (jobDefinition == null)
+			{
+				Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
+				chainController.DestroyChain();
+				return false;
+			}
+
+			chainController.AddJobDefinitionToChain(jobDefinition);
+
+			// Finalize job
+			chainController.FinalizeSetupAndGenerateFirstJob();
+			Main._modEntry.Logger.Log($"Generated new passenger haul job: {chainJobObject.name} ({chainController.currentJobInChain.ID})");
+			passengerChainController = chainController;
+			return true;
+		}
+
+        enum PaxJobGenerationMode
         {
-            try
-            {
-                asm = Main.PaxJobs.Assembly;
-
-                _RouteManager = CompatAccess.Type("PassengerJobs.Generation.RouteManager");
-                _ConsistManager = CompatAccess.Type("PassengerJobs.Generation.ConsistManager");
-                _RouteTrack = CompatAccess.Type("PassengerJobs.Generation.RouteTrack");
-                _PassConsistInfo = CompatAccess.Type("PassengerJobs.Generation.PassConsistInfo");
-                _PassengerJobGenerator = CompatAccess.Type("PassengerJobs.Generation.PassengerJobGenerator");
-                _IPassDestination = CompatAccess.Type("PassengerJobs.Generation.IPassDestination");
-                _PassJobType = CompatAccess.Type("PassengerJobs.Generation.PassJobType");
-                _PassengerChainController = CompatAccess.Type("PassengerJobs.Generation.PassengerChainController");
-                _PassengerHaulJobDefinition = CompatAccess.Type("PassengerJobs.Generation.PassengerHaulJobDefinition");
-                _RouteResult = CompatAccess.Type("PassengerJobs.Generation.RouteResult");
-                _RouteType = CompatAccess.Type("PassengerJobs.Generation.RouteType");
-                _ExpressStationsChainData = CompatAccess.Type("PassengerJobs.Generation.ExpressStationsChainData");
-                _PlatformController = CompatAccess.Type("PassengerJobs.Platforms.PlatformController");
-                _BookletUtility = CompatAccess.Type("PassengerJobs.BookletUtility");
-                _BookletCreator_JobPatch = CompatAccess.Type("PassengerJobs.Patches.BookletCreator_JobPatch");
-                _PassengerJobData = CompatAccess.Type("PassengerJobs.PassengerJobData");
-                _PassStopInfo = CompatAccess.Type("PassengerJobs.PassStopInfo");
-
-                _TryGetInstance = CompatAccess.Method(_PassengerJobGenerator, "TryGetInstance");
-                _GenerateJob = CompatAccess.Method(_PassengerJobGenerator, "GenerateJob", new[] { typeof(JobType), _PassConsistInfo });
-                _GetPassengerCars = CompatAccess.Method(_ConsistManager, "GetPassengerCars");
-                _IsPassengerStation = CompatAccess.Method(_RouteManager, "IsPassengerStation");
-                _GetStationData = CompatAccess.Method(_RouteManager, "GetStationData");
-                _GetRouteTrackById = CompatAccess.Method(_RouteManager, "GetRouteTrackById");
-                _GetPlatforms = CompatAccess.Method(_IPassDestination, "GetPlatforms", new[] { typeof(bool) });
-                _PHJD_GenerateJob = CompatAccess.Method(_PassengerHaulJobDefinition, "GenerateJob", new Type[] { typeof(Station), typeof(float), typeof(float), typeof(string), typeof(JobLicenses) });
-                _GetRoute = CompatAccess.Method(_RouteManager, "GetRoute");
-                _GetRouteType = CompatAccess.Method(_PassJobType, "GetRouteType");
-                _GetJobPaymentData = CompatAccess.Method(_PassengerJobGenerator, "GetJobPaymentData", new[] { typeof(IEnumerable<TrainCarLivery>), typeof(bool) });
-                _GetTotalHaulDistance = CompatAccess.Method(_PassengerJobGenerator, "GetTotalHaulDistance", new[] { typeof(StationController), CompatAccess.IEnumerableOf(_RouteTrack) });
-                _PopulateExpressJobExistingCars = CompatAccess.Method(_PassengerJobGenerator, "PopulateExpressJobExistingCars", new[] { typeof(JobChainController), typeof(Station), _RouteTrack, _RouteResult, typeof(List<Car>), typeof(StationsChainData), typeof(float), typeof(float) });
-                _PaxJGeneratorStartGenerationAsync = CompatAccess.Method(_PassengerJobGenerator, "StartGenerationAsync");
-                _PHJD_CreateBoardingTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateBoardingTask", new[] { _RouteTrack, typeof(float), typeof(bool), typeof(bool) });
-                _PHJD_CreateTransportTask = CompatAccess.Method(_PassengerHaulJobDefinition, "CreateTransportLeg", new[] { typeof(Track), typeof(Track) });
-                _PlatformControllerForTrack = CompatAccess.Method(_PlatformController, "GetControllerForTrack", new[] { typeof(string) });
-                _PlatformRegisterOutgoingJob = CompatAccess.Method(_PlatformController, "RegisterOutgoingJob", new[] { typeof(Job), typeof(bool) });
-                _PlatformRegisterIncomingJob = CompatAccess.Method(_PlatformController, "RegisterIncomingJob", new[] { typeof(Job), typeof(bool) });
-                _ExtractPassengerJobData = CompatAccess.Method(_BookletUtility, "ExtractPassengerJobData", new[] { typeof(Job_data) });
-                _GetBookletTemplateData = CompatAccess.Method(_BookletCreator_JobPatch, "GetBookletTemplateData", new[] { typeof(Job_data) });
-                _CreateLoadTaskPage = CompatAccess.Method(_BookletUtility, "CreateLoadTaskPage", new[] { _PassengerJobData, _PassStopInfo, typeof(int), typeof(int), typeof(int) });
-                _CreateCoupleTaskPage = CompatAccess.Method(_BookletUtility, "CreateCoupleTaskPage", new[] { _PassengerJobData, typeof(int), typeof(int), typeof(int) });
-
-                _AllTracksProperty = CompatAccess.Property(_IPassDestination, "AllTracks");
-                _RouteTrackLengthProp = CompatAccess.Property(_RouteTrack, "Length");
-                _TrainCarsToTransportProp = CompatAccess.Property(_PassengerHaulJobDefinition, "TrainCarsToTransport");
-                _PaxStYardIdProperty = CompatAccess.Property(_IPassDestination, "YardID");
-                _RTPlatformIdProp = CompatAccess.Property(_RouteTrack, "PlatformID");
-
-                _RouteTrackTrackField = CompatAccess.Field(_RouteTrack, "Track");
-                _StartingTrackField = CompatAccess.Field(_PassengerHaulJobDefinition, "StartingTrack");
-                _DestinationTracksField = CompatAccess.Field(_PassengerHaulJobDefinition, "DestinationTracks");
-                _TaskStartingTrackField = CompatAccess.Field(typeof(TransportTask), "startingTrack");
-                _RouteResultTracksField = CompatAccess.Field(_RouteResult, "Tracks");
-                _RouteTrackStationField = CompatAccess.Field(_RouteTrack, "Station");
-                _PaxJGeneratorStContField = CompatAccess.Field(_PassengerJobGenerator, "Controller");
-                _PHJD_RouteTypeField = CompatAccess.Field(_PassengerHaulJobDefinition, "RouteType");
-                _StaticJobDefJobField = CompatAccess.Field(typeof(StaticJobDefinition), "<job>k__BackingField");
-                _InitialStopField = CompatAccess.Field(_PassengerJobData, "initialStop");
-
-                _RouteTrackCtor = CompatAccess.Ctor(_RouteTrack, new[] { _IPassDestination, typeof(Track) });
-                _PassConsistInfoCtor = CompatAccess.Ctor(_PassConsistInfo, new[] { _RouteTrack, typeof(List<Car>) });
-                _PassengerJccCtor = CompatAccess.Ctor(_PassengerChainController, new[] { typeof(GameObject) });
-                _ExpressStChainDataCtor = CompatAccess.Ctor(_ExpressStationsChainData, new[] { typeof(string), Type.GetType("System.String[]") });
-
-                _Random = new Random();
-
-                _PassengerExpress = Traverse.Create(_PassJobType).Field("Express").GetValue<JobType>();
-                _PassengerLocal = Traverse.Create(_PassJobType).Field("Local").GetValue<JobType>();
-
-                _RouteTypeExpress = Enum.Parse(_RouteType, "Express");
-                _RouteTypeLocal = Enum.Parse(_RouteType, "Local");
-
-                //_AllPlatformControllers ??= UnityEngine.Object.FindObjectsOfType(_PlatformController) ?? throw new KeyNotFoundException("No platform controllesr present, this shouldn´t happen");
-
-                PatchPrefix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Prefix));
-                PatchPostfix(_PHJD_GenerateJob, typeof(PaxJobsCompat), nameof(GenerateJob_Postfix));
-
-                PatchPrefix(_PaxJGeneratorStartGenerationAsync, typeof(PaxJobsCompat), nameof(StartGenerationAsync_Prefix));
-
-                PatchPrefix(_ExtractPassengerJobData, typeof(PaxJobsCompat), nameof(ExtractPassengerJobData_Prefix));
-
-                PatchPostfix(_GetBookletTemplateData, typeof(PaxJobsCompat), nameof(GetBookletTemplateData_Postfix));
-
-                PatchPrefix(_CreateLoadTaskPage, typeof(PaxJobsCompat), nameof(CreateLoadTaskPage_Prefix));
-
-                PatchPrefix(_CreateCoupleTaskPage, typeof(PaxJobsCompat), nameof(CreateCoupleTaskPage_Prefix));
-
-            }
-            catch (Exception e)
-            {
-                Main._modEntry.Logger.LogException("Failed to initilize PaxJobsCompat when resolving types and methods", e);
-                return false;
-            }
-
-            return true;
-        }
-
-        public class Tags
-        {
-            public sealed class RouteManager { };
-            public sealed class ConsistManager { };
-            public sealed class RouteTrack { };
-            public sealed class PassConsistInfo { };
-            public sealed class PassengerJobGenerator { };
-            public sealed class IPassDestination { };
-            public sealed class PassJobType { };
-            public sealed class PassengerChainController { };
-            public sealed class PassengerHaulJobDefinition { };
-            public sealed class RouteResult { };
-            public sealed class RouteType { };
-            public sealed class ExpressStationsChainData { };
-            public sealed class PlatformController { };
-            public sealed class PassengerJobData { };
-        }
-        #endregion
-
-        public static bool OverrideSpawnFlagForPaxJ = false;
-
-        private static bool TryGetGenerator(string yardId, out object generator)
-        {
-            generator = null;
-            var args = new object[] { yardId, null };
-            if (!(bool)_TryGetInstance.Invoke(null, args))
-            {
-                Main._modEntry.Logger.Error($"Couldn´t get instance of PaxJobsGenerator for {yardId}");
-                return false;
-            }
-
-            generator = args[1];
-            return generator != null;
-        }
-
-        public static void PaxJobsOrigGenJobsInStation(string yardId)
-        {
-            if (!TryGetGenerator(yardId, out object generator))
-            {
-                Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
-                return;
-            }
-            _PaxJGeneratorStartGenerationAsync.Invoke(generator, new object[0]);
-            Main._modEntry.Logger.Log($"Started PaxJ generation with cars in {yardId}");
-        }
-
-        //public static bool TryGenerateJob(string yardId, JobType jobType, object passConsistInfo, out JobChainController passengerChainController)
-        private static bool TryGenerateJob(StationController station, JobType jobType, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, out JobChainController passengerChainController)
-        {
-            passengerChainController = null;
-            if (!AStartGameData.carsAndJobsLoadingFinished) return false;
-            if (trainCars.Any(tc => tc.LoadedCargoAmount > 0.001f)) Main._modEntry.Logger.Log("Cars have cargo...");
-            Main._modEntry.Logger.Log($"Attempting to generate job of type {jobType} in {YardIdFromPaxStation(GetRouteTrackStationField(startingRouteTrack))}");
-
-            /*if (!TryGetGenerator(yardId, out object generator))
-            {
-                Main._modEntry.Logger.Error($"PaxJobsGenerator for {yardId} was null, this shouldn´t happen!");
-                return false;
-            }
-
-            passengerChainController = (JobChainController)_GenerateJob.Invoke(generator, new object[] { jobType, passConsistInfo });*/
-
-            if (!SetupAndGenerateJob(station, startingRouteTrack, trainCars, jobType, out passengerChainController))
-            {
-                Main._modEntry.Logger.Error("Couldn´t generate PaxJob - problem in build-up");
-                return false;
-            }
-
-            if (passengerChainController == null || passengerChainController.currentJobInChain == null) Main._modEntry.Logger.Error("JobChainController or its job is null, this shouldn´t happen!"); ;
-            return passengerChainController != null;
-        }
-
-        private static RouteTrackRef CreateRouteTrack(IPassDestinationRef IPassDestination, Track terminalTrack) => new(_RouteTrackCtor.Invoke(new object[] { IPassDestination.Value, terminalTrack }));
-
-        private static object CreatePassConsistInfo(RouteTrackRef routeTrack, List<Car> cars) => _PassConsistInfoCtor.Invoke(new object[] { routeTrack.Value, cars });
-
-        private static PassengerChainControllerRef CreatePassJcc(GameObject jobChainGameObject) => new(_PassengerJccCtor.Invoke(new object[] { jobChainGameObject }));
-
-        private static ExpressStationsChainDataRef CreateExpressStationsChainData(string chainOriginYardId, string[] chainDestinationYardIds) => new(_ExpressStChainDataCtor.Invoke(new object[] { chainOriginYardId, chainDestinationYardIds }));
-
-        public static bool IsPaxJobDefinition(StaticJobDefinition jobDefinition, out PassengerHaulJobDefinitionRef passengerHaulJobDefinition)
-        {
-            passengerHaulJobDefinition = new(null);
-            if (jobDefinition == null) return false;
-            var job = jobDefinition.job;
-            if (job == null) return false;
-            bool correctType = (job.jobType == _PassengerExpress || job.jobType == _PassengerLocal);
-            bool correctDef = _PassengerHaulJobDefinition.IsInstanceOfType(jobDefinition);
-            passengerHaulJobDefinition = new(jobDefinition);
-            return correctType && correctDef;
-        }
-
-        public static bool IsPaxCars(TrainCar car)
-        {
-            var carLiveries = (IEnumerable<TrainCarLivery>)_GetPassengerCars.Invoke(null, null);
-            return carLiveries != null && car.carLivery != null && carLiveries.Contains(car.carLivery);
-        }
-
-        public static float GetConsistLength(List<TrainCar> trainCars)
-        {
-            return CarSpawner.Instance.GetTotalCarsLength(
-                TrainCar.ExtractLogicCars(trainCars),
-                true
-            );
-        }
-
-        private static bool IsPassengerStation(string yardId) => (bool)(_IsPassengerStation?.Invoke(null, new object[] { yardId }));
-
-        public static List<StationController> AllPaxStations() => StationController.allStations.Where(st => IsPassengerStation(st.stationInfo.YardID)).ToList();
-
-        private static IPassDestinationRef GetStationData(string yardId) => new(_GetStationData.Invoke(null, new object[] { yardId })); // output is IPassDestination : PassStationData
-
-        private static RouteResultRef GetRoute(string yardId, object routeType, IEnumerable<string> existingDests, double minLength = 0) => new(_GetRoute?.Invoke(null, new object[] { GetStationData(yardId).Value, routeType, existingDests, minLength }));
-
-        private static RouteTrackRef GetRouteTrackByIdOrNull(string trackFullDisplayId)
-        {
-            RouteTrackRef routeTrack = new(_GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId }));
-            if (routeTrack.Value is null) return new(null);
-            Track trackField = GetRouteTrackTrackField(routeTrack);
-            if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return new(null);
-            return routeTrack;
-        }
-
-        private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId).Value)).ToList();
-
-        private static string YardIdFromPaxStation(IPassDestinationRef passStationData) => (string)_PaxStYardIdProperty.GetValue(passStationData.Value);
-
-        private static IEnumerable<RouteTrackRef> GetPlatforms(IPassDestinationRef stationData, bool onlyTerminusTracks = false)
-        {
-            var result = _GetPlatforms.Invoke(stationData.Value, new object[] { onlyTerminusTracks });
-            if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return new(item);
-        }
-
-        private static List<Track> GetStorageTracks(string yardId) => AllPaxTracksForStationData(yardId).Except(GetPlatforms(GetStationData(yardId)).Select(rt => GetRouteTrackTrackField(rt)).ToList()).ToList();
-
-        private static Track GetRouteTrackTrackField(RouteTrackRef routeTrack)
-        {
-            if (routeTrack.Value == null) return null;
-            var track = (Track)_RouteTrackTrackField.GetValue(routeTrack.Value);
-            if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
-            return track;
-        }
-
-        private static IPassDestinationRef GetRouteTrackStationField(RouteTrackRef routeTrack)
-        {
-            if (routeTrack.Value == null) return new(null);
-            var iPassDest = _RouteTrackStationField.GetValue(routeTrack.Value);
-            if (iPassDest == null) return new(null);
-            return new(iPassDest);
-        }
-
-        //private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(_AllPlatformControllers.ToList().WhereNotNull().First(), new object[] {id}));
-        private static PlatformControllerRef GetPlatformControllerForTrack(string id) => new(_PlatformControllerForTrack.Invoke(null, new object[] { id }));
-
-        private static string GetRouteTrackPlatformIdField(RouteTrackRef routeTrack) => (string)_RTPlatformIdProp.GetValue(routeTrack.Value);
-
-        private static double GetRouteTrackLength(RouteTrackRef routeTrack) => (double)_RouteTrackLengthProp.GetValue(routeTrack.Value);
-
-        private static PaymentCalculationData GetJobPaymentData(IEnumerable<TrainCarLivery> carTypes, bool empty = false) => (PaymentCalculationData)_GetJobPaymentData.Invoke(null, new object[] { carTypes, empty });
-
-        private static bool CanFitInStation(IPassDestinationRef stationData, List<TrainCar> trainCars) => GetPlatforms(stationData).Any(rt => (float)GetConsistLength(trainCars) <= GetRouteTrackLength(rt));
-
-        private static RouteTypeRef GetRouteType(JobType type) => new(_GetRouteType.Invoke(null, new object[] { type }));
-
-        private static object GetRouteResultTracksArray(RouteResultRef routeResult) => _RouteResultTracksField.GetValue(routeResult.Value);
-
-        private static float GetTotalHaulDistance(StationController startStation, Array destinations) => (float)_GetTotalHaulDistance.Invoke(null, new object[] { startStation, destinations });
-
-        private static JobType PickPassengerJobType(int carCount)
-        {
-            if (carCount <= 4)
-                return (JobType)_Random.Next(101, 103); // Express or Local
-
-            return _PassengerExpress;
-        }
-
-        private static PassengerHaulJobDefinitionRef PopulateExpressJobExistingCars(JobChainController chainController, Station startStation, RouteTrackRef startTrack, RouteResultRef routeResult, List<Car> logicCars, StationsChainData chainData, float timeLimit, float initialPay) => new(_PopulateExpressJobExistingCars?.Invoke(null, new object[] { chainController, startStation, startTrack.Value, routeResult.Value, logicCars, chainData, timeLimit, initialPay }));
-
-        private static Task CreatePaxBoardingTask(RouteTrackRef platform, float totalCapacity, bool loading, bool isFinal, object __instance) => (Task)(_PHJD_CreateBoardingTask.Invoke(__instance, new object[] { platform.Value, totalCapacity, loading, isFinal }));
-
-        private static Task CreatePaxTransportTask(Track startingTrack, Track endTrack, object __instance) => (Task)_PHJD_CreateTransportTask.Invoke(__instance, new object[] { startingTrack, endTrack });
-
-        private static RouteTrackRef SelectStartPlatformRouteTrack(Track currentTrack, List<RouteTrackRef> fittingPlatforms)
-        {
-            if (!fittingPlatforms.Any()) return new(null);
-
-            if (currentTrack != null)
-            {
-                string currentTrackId = currentTrack.ID.FullDisplayID;
-                var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
-                {
-                    var track = GetRouteTrackTrackField(rt);
-                    return track != null && track.ID.FullDisplayID == currentTrackId;
-                });
-
-                if (matchingPlatform.Value != null)
-                {
-                    Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
-                    return matchingPlatform;
-                }
-                Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random free platform");
-            }
-            else Main._modEntry.Logger.Log("Could not determine current track, selecting random free platform");
-
-            return fittingPlatforms.OrderByDescending(p =>
-            {
-                var track = GetRouteTrackTrackField(p) ?? new Track(0);
-                return track.length - track.OccupiedLength;
-            }).FirstOrDefault();
-        }
-
-        private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<RouteTrackRef> fittingPlatforms, JobType jobType)
-        {
-            List<JobChainController> result = new();
-            if (trainCars.Count() > 20)
-            {
-                result.AddRange(HandleSplitOrFail(trainCars, station));
-                return result;
-            }
-
-            Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-            var preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
-            if (preferredRouteTrack.Value == null || GetRouteTrackTrackField(preferredRouteTrack).ID == null)
-            {
-                Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
-                result.AddRange(HandleSplitOrFail(trainCars, station));
-                return result;
-            }
-
-            if (!fittingPlatforms.Contains(preferredRouteTrack))
-            {
-                Main._modEntry.Logger.Error("Selected RouteTrack is not in fitting platforms list");
-                return result;
-            }
-
-            Main._modEntry.Logger.Log($"Picked platform {GetRouteTrackTrackField(preferredRouteTrack).ID.FullDisplayID} ");
-
-            //if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(cars)), out JobChainController passangerChainController))
-            if (TryGenerateJob(station, jobType, preferredRouteTrack, trainCars, out JobChainController passangerChainController))
-            {
-                Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
-                result.Add(passangerChainController);
-                return result;
-            }
-
-            result.AddRange(HandleSplitOrFail(trainCars, station));
-            return result;
-        }
-
-        private static List<JobChainController> HandleSplitOrFail(List<TrainCar> trainCars, StationController station)
-        {
-            List<JobChainController> result = new();
-            if (trainCars.Count < 2)
-            {
-                Main._modEntry.Logger.Error($"Single pax car {trainCars.First().ID} cannot be reassigned");
-                return result;
-            }
-
-            var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(new List<IReadOnlyList<TrainCar>> { trainCars });
-            if (emptyConsecutiveTrainCarGroups.Any())
-            {
-                foreach (var emptyTrainCars in emptyConsecutiveTrainCarGroups)
-                {
-                    Main._modEntry.Logger.Log($"Spilitting consist starting with car {emptyTrainCars.First().ID}");
-                    var (first, second) = emptyTrainCars.SplitInHalf();
-                    HandleEmptyPaxCars(first, station, out List<JobChainController> outJobChainControllers);
-                    result.AddRange(outJobChainControllers);
-                    HandleEmptyPaxCars(second, station, out outJobChainControllers);
-                    result.AddRange(outJobChainControllers);
-                }
-            }
-
-            if (loadedConsecutiveTrainCarGroups.Any())
-            {
-                foreach (var loadedTrainCars in loadedConsecutiveTrainCarGroups)
-                {
-                    Main._modEntry.Logger.Log($"Spilitting consist starting with car {loadedTrainCars.First().ID}");
-                    var (first, second) = loadedTrainCars.SplitInHalf();
-                    HandleLoadedPaxCars(first, station, out List<JobChainController> outJobChainControllers);
-                    result.AddRange(outJobChainControllers);
-                    HandleLoadedPaxCars(second, station, out outJobChainControllers);
-                    result.AddRange(outJobChainControllers);
-                }
-            }
-
-            return result;
-        }
-
-        private static (List<IReadOnlyList<TrainCar>>, List<IReadOnlyList<TrainCar>>) SortCGIntoEmptyAndLoaded(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups)
-        {
-            var statusTrainCarGroups = paxConsecutiveTrainCarGroups.SelectMany(cars => cars.GroupConsecutiveBy(tc => GetTrainCarReassignStatus(tc))).ToList();
-            var emptyConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Empty).Select(s => s.Items).ToList();
-            var loadedConsecutiveTrainCarGroups = statusTrainCarGroups.Where(s => s.Key == TrainCarReassignStatus.Loaded).Select(s => s.Items).ToList();
-
-            Main._modEntry.Logger.Log($"Found {emptyConsecutiveTrainCarGroups.Count} empty pax train car groups with a total of {emptyConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
-            Main._modEntry.Logger.Log($"Found {loadedConsecutiveTrainCarGroups.Count} loaded pax train car groups with a total of {loadedConsecutiveTrainCarGroups.SelectMany(g => g).Count()} cars");
-            return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
-        }
-
-        private static void AddTransportTaskToTop(StaticJobDefinition staticPaxJobDefinition, Track currentTrack, Track destinatiionTrack, List<Car> cars)
-        {
-            if (staticPaxJobDefinition != null)
-            {
-                if (staticPaxJobDefinition.job == null)
-                {
-                    Main._modEntry.Logger.Error("staticJobDefinition.job is null");
-                    return;
-                }
-                var job = staticPaxJobDefinition.job;
-                Main._modEntry.Logger.Log($"Attempting to add task to {job.ID}");
-                var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
-                if (headSequentialTask != null)
-                {
-                    var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
-                    newTransportTask.SetJobBelonging(job);
-                    headSequentialTask.tasks.AddFirst(newTransportTask);
-                }
-                else Main._modEntry.Logger.Error($"Couldn´t extract head sequential task of {job.ID}");
-            }
-            else Main._modEntry.Logger.Error($"Couldn´t get job definition");
-
-        }
-
-        public static List<JobChainController> DecideForPaxCarGroups(List<IReadOnlyList<TrainCar>> paxConsecutiveTrainCarGroups, StationController station)
-        {
-            List<JobChainController> result = new();
-            Main._modEntry.Logger.Log($"Reassigning passanger cars to jobs in station {station.logicStation.ID}");
-
-            EnsureTrainCarsAreConvertedToNonPlayerSpawned(FilterTrainCarGroups(paxConsecutiveTrainCarGroups).SelectMany(tcg => tcg).ToList());
-
-            var (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups) = SortCGIntoEmptyAndLoaded(paxConsecutiveTrainCarGroups);
-            foreach (List<TrainCar> tcs in emptyConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
-            {
-                HandleEmptyPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
-                result.AddRange(jobChainControllers);
-            }
-            foreach (List<TrainCar> tcs in loadedConsecutiveTrainCarGroups.Cast<List<TrainCar>>())
-            {
-                Main._modEntry.Logger.Log($"Loaded consist of {tcs.Count()} pax cars starting with {tcs.First().ID} is in station {station.stationInfo.Name}");
-                //handling complicated - no inbuilt methods for job generation from already loaded cars
-
-                HandleLoadedPaxCars(tcs, station, out List<JobChainController> jobChainControllers);
-                result.AddRange(jobChainControllers);
-            }
-
-            return result;
-        }
-
-        public static List<IReadOnlyList<TrainCar>> FilterTrainCarGroups(List<IReadOnlyList<TrainCar>> trainCarGroups)
-        {
-            trainCarGroups.RemoveAll(trainCars =>
-            {
-                if (trainCars == null || trainCars.Count == 0)
-                {
-                    Main._modEntry.Logger.Error("[FilterTrainCarGroups] Invalid cars input thrown out");
-                    return true;
-                }
-                if (CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars) == null) return true;
-
-                return trainCars.All(tc => tc.derailed);
-            });
-            return trainCarGroups;
-        }
-
-        private static Track GetRandomFittingStorageTrack(StationController targetStation, List<TrainCar> trainCars)
-        {
-            var fittingSPTracks = GetStationData(targetStation.stationInfo.YardID).Value != null ? (GetStorageTracks(targetStation.stationInfo.YardID).Where(t => GetConsistLength(trainCars) <= t.length).ToList()) : new List<Track>();
-            return !fittingSPTracks.Any() ? null : fittingSPTracks.GetRandomElement();
-        }
-
-        private static List<RouteTrackRef> GetFittingPlatformsForStation(StationController station, List<TrainCar> trainCars, bool onlyTerminusTracks = false)
-        {
-            var stationData = GetStationData(station.stationInfo.YardID);
-            return stationData.Value == null ? new List<RouteTrackRef>() : (GetPlatforms(stationData, onlyTerminusTracks).Where(rt => GetConsistLength(trainCars) <= GetRouteTrackLength(rt)).ToList());
-        }
-
-        private static float CalculateCrowDistanceBetweenThings(Vector3 thing1, Vector3 thing2) => (thing1 - thing2).sqrMagnitude;
-
-        private static StationController FindDestinationStation(StationController origin, List<TrainCar> trainCars) => AllPaxStations().Distinct().Where(st => st != origin).Where(st => CanFitInStation(GetStationData(st.stationInfo.YardID), trainCars)).OrderBy(sc => CalculateCrowDistanceBetweenThings(trainCars.First().transform.position, sc.stationRange.transform.position)).FirstOrDefault();
-
-        private static bool FilterJobDataForModPaxJob(ref Job_data job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit)
-        {
-            firstNestedTask = null;
-            taskSequence = null;
-
-            if (job.tasksData == null || job.tasksData.Length == 0)
-            {
-                exit = true;
-                return false;
-            }
-
-            taskSequence = job.tasksData[0];
-            if (taskSequence.type != TaskType.Sequential || taskSequence.nestedTasks?.Length < 1)
-            {
-                exit = true;
-                return false;
-            }
-
-            firstNestedTask = taskSequence.nestedTasks[0];
-            if (firstNestedTask.instanceTaskType != TaskType.Transport)
-            {
-                exit = true;
-                return true;
-            }
-
-            exit = false;
-            return false;
-        }
-
-        private static bool TryGetStationContext(List<TrainCar> trainCars, StationController station, out Track startingTrack)
-        {
-            startingTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-            if (startingTrack == null)
-            {
-                Main._modEntry.Logger.Error("No starting track found");
-                return false;
-            }
-
-            if (startingTrack.ID.yardId != station.stationInfo.YardID)
-            {
-                Main._modEntry.Logger.Error("Station mismatch");
-                return false;
-            }
-            return true;
-        }
-
-        private static bool SetupAndGenerateJob(StationController startingStation, RouteTrackRef startingRouteTrack, List<TrainCar> trainCars, JobType jobType, out JobChainController passengerChainController)
-        {
-            passengerChainController = null;
-            //object startingRouteTrack = GetRouteTrackByIdOrNull(startingTrack.ID.FullDisplayID);
-            var currentDests = startingStation.logicStation.availableJobs
-                .Where(j => (j.jobType == _PassengerExpress) || (j.jobType == _PassengerLocal))
-                .Select(j => j.chainData.chainDestinationYardId);
-
-            var destinations = GetRoute(startingStation.stationInfo.YardID, GetRouteType(jobType).Value, currentDests, GetConsistLength(trainCars));
-            if (destinations.Value == null) return false;
-
-            var jobCarTypes = TrainCar.ExtractLogicCars(trainCars).Select(c => c.carType).ToList();
-
-            if (GetRouteResultTracksArray(destinations) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
-            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new Foreign<RouteTrackRef>(o)).Select(rt => (Track)_RouteTrackTrackField.GetValue(rt.Value)).ToList();
-            var destinationRouteTracksYardIDs = rrTracksArray.Cast<object>().Select(d => YardIdFromPaxStation(GetRouteTrackStationField(new RouteTrackRef(d))));
-
-            // create job chain controller
-            string destString = string.Join(" - ", destinationRouteTracksYardIDs);
-            var chainJobObject = new GameObject($"ChainJob[Passenger]: {startingStation.stationInfo.YardID} - {destString}");
-            chainJobObject.transform.SetParent(startingStation.transform);
-            var chainController = (JobChainController)CreatePassJcc(chainJobObject).Value;
-
-            var chainData = (StationsChainData)CreateExpressStationsChainData(startingStation.stationInfo.YardID, destinationRouteTracksYardIDs.ToArray()).Value;
-            PaymentCalculationData transportPaymentData = GetJobPaymentData(jobCarTypes);
-
-            float haulDistance = GetTotalHaulDistance(startingStation, rrTracksArray);
-            float bonusLimit = JobPaymentCalculator.CalculateHaulBonusTimeLimit(haulDistance, false);
-            float transportPayment = JobPaymentCalculator.CalculateJobPayment(JobType.Transport, haulDistance, transportPaymentData);
-
-            chainController.carsForJobChain = TrainCar.ExtractLogicCars(trainCars);
-
-            var jobDefinition = (StaticJobDefinition)PopulateExpressJobExistingCars(chainController, startingStation.logicStation, startingRouteTrack, destinations, TrainCar.ExtractLogicCars(trainCars), chainData, bonusLimit, transportPayment).Value;
-            if (jobDefinition == null)
-            {
-                Main._modEntry.Logger.Warning($"Failed to generate transport job definition for {chainController.jobChainGO.name}");
-                chainController.DestroyChain();
-                return false;
-            }
-
-            chainController.AddJobDefinitionToChain(jobDefinition);
-
-            // Finalize job
-            chainController.FinalizeSetupAndGenerateFirstJob();
-            Main._modEntry.Logger.Log($"Generated new passenger haul job: {chainJobObject.name} ({chainController.currentJobInChain.ID})");
-            passengerChainController = chainController;
-            return true;
-        }
-
-        private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false)
-        {
-            // taken from PaxJobs - mostly original method code - in order to avoid using transpiler
-            float totalCapacity = 0;
-            foreach (var car in cars) totalCapacity += car.capacity;
-            var taskList = new List<Task>();
-            Track currentCarsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
-            Track initialTransportDestTrack = null;
-
-            if (!loaded)
-            {
-                var initialLoad = CreatePaxBoardingTask(startingRouteTrack, totalCapacity, true, false, __instance);
-                taskList.Add(initialLoad);
-            }
-            if (tracksMismatch) initialTransportDestTrack = GetRouteTrackTrackField(startingRouteTrack);
-            //there has to be some task based in the originating station to get couple page to exist
-            var initialTransportTask = CreatePaxTransportTask(currentCarsTrack, initialTransportDestTrack ?? currentCarsTrack, __instance);
-            taskList.Insert(0, initialTransportTask);
-
-            List<string> destinationRouteTracksYardIDs = new();
-
-            for (int i = 0; i < destinationTracks.Count; i++)
-            {
-                bool isLast = (i == (destinationTracks.Count - 1));
-                var unloadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, false, isLast, __instance);
-                taskList.Add(unloadTask);
-
-                if (!isLast)
-                {
-                    var loadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, true, false, __instance);
-                    taskList.Add(loadTask);
-                }
-
-                destinationRouteTracksYardIDs.Add(GetRouteTrackTrackField(destinationTracks[i]).ID.yardId);
-            }
-
-            var chainData = (StationsChainData)CreateExpressStationsChainData(jobOriginStation.ID, destinationRouteTracksYardIDs.ToArray()).Value;
-            var superTask = new SequentialTasks(taskList);
-            var currentRouteType = _PHJD_RouteTypeField.GetValue(__instance);
-            var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
-            StaticJobDefinition baseJobDef = (StaticJobDefinition)__instance;
-            var newJob = new Job(superTask, jobType, timeLimit, initialWage, chainData, forcedJobId, requiredLicenses);
-            _StaticJobDefJobField.SetValue(__instance, newJob);
-
-            if (!loaded)
-            {
-                var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
-                _PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
-            }
-
-            for (int i = 0; i < destinationTracks.Count - 1; i++)
-            {
-                var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks[i])).Value;
-                newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
-            }
-
-            var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks.Last())).Value;
-            newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
-
-            jobOriginStation.AddJobToStation(baseJobDef.job);
-            return true;
-        }
-
-        private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
-        {
-            jobChainControllers = new();
-
-            if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
-
-            if (IsPassengerStation(station.stationInfo.YardID))
-            {
-                var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
-
-                if (!fittingPlatforms.Any())
-                {
-                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-                    return;
-                }
-
-                JobType jobType = PickPassengerJobType(trainCars.Count);
-                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal;
-                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
-                return;
-            }
-            else
-            {
-                Main._modEntry.Logger.Log($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get unloaded");
-                //generate FH job to random pax station: use already existing mod logic elswhere
-                StationController viableDestStation = FindDestinationStation(station, trainCars);
-                if (viableDestStation != null)
-                {
-                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
-                    JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
-                    if (transportJobChainController != null)
-                    {
-                        transportJobChainController.FinalizeSetupAndGenerateFirstJob();
-                        jobChainControllers.Add(transportJobChainController);
-                        return;
-                    }
-                }
-                else
-                {
-                    Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a FH to any pax station, attempting splitting");
-                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-                    return;
-                }
-            }
-
-            Main._modEntry.Logger.Error("[HandleLoadedPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
-        }
-
-        private static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
-        {
-            jobChainControllers = new();
-
-            if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
-
-            if (IsPassengerStation(station.stationInfo.YardID))
-            {
-                var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
-
-                if (!fittingPlatforms.Any())
-                {
-                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-                    return;
-                }
-
-                JobType jobType = PickPassengerJobType(trainCars.Count);
-                if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes <-- do this dynamically from PaxJobs routes list?
-                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
-                return;
-            }
-            else
-            {
-                Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned a pax job");
-                //generate LH job to random pax station: use already existing mod logic elswhere
-                StationController viableDestStation = FindDestinationStation(station, trainCars);
-                if (viableDestStation != null)
-                {
-                    Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
-                    JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
-                    if (emptyHaulJobChainController != null)
-                    {
-                        emptyHaulJobChainController.FinalizeSetupAndGenerateFirstJob();
-                        jobChainControllers.Add(emptyHaulJobChainController);
-                        return;
-                    }
-                }
-                else
-                {
-                    Main._modEntry.Logger.Error($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
-                    jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
-                    return;
-                }
-            }
-
-            Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+            Vanilla,                    
+            Empty_OnPlatform,
+            Empty_OffPlatform,
+            Loaded,
+            Loaded_Taken_FromSave,
+            Empty_Taken_FromSave
         }
 
 
-        #region PaxJobs Patches
+
+        private static bool GeneratePaxJobOverride(List<Car> cars, RouteTrackRef startingRouteTrack, List<RouteTrackRef> destinationTracks, object __instance, Station jobOriginStation, float timeLimit = 0, float initialWage = 0, string forcedJobId = null, JobLicenses requiredLicenses = JobLicenses.Basic, bool loaded = false, bool tracksMismatch = false, bool fromSave = false, bool taken = false)
+		{
+			// taken from PaxJobs - mostly original method code - in order to avoid using transpiler
+			float totalCapacity = 0;
+			foreach (var car in cars) totalCapacity += car.capacity;
+			var taskList = new List<Task>();
+			Track currentCarsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
+			Track initialTransportDestTrack = null;
+
+			if (!loaded)
+			{
+				var initialLoad = CreatePaxBoardingTask(startingRouteTrack, totalCapacity, true, false, __instance);
+				taskList.Add(initialLoad);
+			}
+			if (tracksMismatch) initialTransportDestTrack = GetRouteTrackTrackField(startingRouteTrack);
+			if (taken) initialTransportDestTrack = GetRouteTrackTrackField(GetFittingPlatformsForStation(StationController.GetStationByYardID(jobOriginStation.ID), TrainCar.ExtractTrainCars(cars)).GetRandomElement());
+			//there has to be some task based in the originating station to get couple page to exist
+			var initialTransportTask = CreatePaxTransportTask((fromSave ? initialTransportDestTrack : currentCarsTrack), initialTransportDestTrack ?? currentCarsTrack, __instance);
+			taskList.Insert(0, initialTransportTask);
+
+			List<string> destinationRouteTracksYardIDs = new();
+
+			for (int i = 0; i < destinationTracks.Count; i++)
+			{
+				bool isLast = (i == (destinationTracks.Count - 1));
+				var unloadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, false, isLast, __instance);
+				taskList.Add(unloadTask);
+
+				if (!isLast)
+				{
+					var loadTask = CreatePaxBoardingTask(destinationTracks[i], totalCapacity, true, false, __instance);
+					taskList.Add(loadTask);
+				}
+
+				destinationRouteTracksYardIDs.Add(GetRouteTrackTrackField(destinationTracks[i]).ID.yardId);
+			}
+
+			var chainData = (StationsChainData)CreateExpressStationsChainData(jobOriginStation.ID, destinationRouteTracksYardIDs.ToArray()).Value;
+			var superTask = new SequentialTasks(taskList);
+			var currentRouteType = _PHJD_RouteTypeField.GetValue(__instance);
+			var jobType = currentRouteType.Equals(_RouteTypeExpress) ? _PassengerExpress : _PassengerLocal;
+			StaticJobDefinition baseJobDef = (StaticJobDefinition)__instance;
+			var newJob = new Job(superTask, jobType, timeLimit, initialWage, chainData, forcedJobId, requiredLicenses);
+			_StaticJobDefJobField.SetValue(__instance, newJob);
+
+			if (!loaded)
+			{
+				var startPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(startingRouteTrack)).Value;
+				_PlatformRegisterOutgoingJob.Invoke(startPlatController, new object[] { newJob, false });
+			}
+
+			for (int i = 0; i < destinationTracks.Count - 1; i++)
+			{
+				var destPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks[i])).Value;
+				newJob.JobTaken += (j, _) => _PlatformRegisterOutgoingJob.Invoke(destPlatController, new object[] { j, false });
+			}
+
+			var finalPlatController = GetPlatformControllerForTrack(GetRouteTrackPlatformIdField(destinationTracks.Last())).Value;
+			newJob.JobTaken += (j, _) => _PlatformRegisterIncomingJob.Invoke(finalPlatController, new object[] { j, false });
+
+			jobOriginStation.AddJobToStation(baseJobDef.job);
+			return true;
+		}
+
+		private static void HandleLoadedPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
+		{
+			jobChainControllers = new();
+
+			if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
+
+			if (IsPassengerStation(station.stationInfo.YardID))
+			{
+				var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
+
+				if (!fittingPlatforms.Any())
+				{
+					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+					return;
+				}
+
+				JobType jobType = PickPassengerJobType(trainCars.Count);
+				if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal;
+				jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
+				return;
+			}
+			else
+			{
+				Main._modEntry.Logger.Log($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get unloaded");
+				//generate FH job to random pax station: use already existing mod logic elswhere
+				StationController viableDestStation = FindDestinationStation(station, trainCars);
+				if (viableDestStation != null)
+				{
+					Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
+					JobChainController transportJobChainController = TransportJobGenerator.TryGenerateJobChainController(station, startingTrack, viableDestStation, trainCars, trainCars.Select(tc => tc.LoadedCargo).ToList(), _Random, false, possibleDestinationTrack);
+					if (transportJobChainController != null)
+					{
+						transportJobChainController.FinalizeSetupAndGenerateFirstJob();
+						jobChainControllers.Add(transportJobChainController);
+						return;
+					}
+				}
+				else
+				{
+					Main._modEntry.Logger.Error($"Loaded consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a FH to any pax station, attempting splitting");
+					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+					return;
+				}
+			}
+
+			Main._modEntry.Logger.Error("[HandleLoadedPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+		}
+
+		private static void HandleEmptyPaxCars(List<TrainCar> trainCars, StationController station, out List<JobChainController> jobChainControllers)
+		{
+			jobChainControllers = new();
+
+			if (!TryGetStationContext(trainCars, station, out Track startingTrack)) return;
+
+			if (IsPassengerStation(station.stationInfo.YardID))
+			{
+				var fittingPlatforms = GetFittingPlatformsForStation(station, trainCars);
+
+				if (!fittingPlatforms.Any())
+				{
+					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+					return;
+				}
+
+				JobType jobType = PickPassengerJobType(trainCars.Count);
+				if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes <-- do this dynamically from PaxJobs routes list?
+				jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
+				return;
+			}
+			else
+			{
+				Main._modEntry.Logger.Log($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} on track {startingTrack.ID.FullID} needs to be transported to a pax jobs station to get reassigned a pax job");
+				//generate LH job to random pax station: use already existing mod logic elswhere
+				StationController viableDestStation = FindDestinationStation(station, trainCars);
+				if (viableDestStation != null)
+				{
+					Track possibleDestinationTrack = GetRandomFittingStorageTrack(viableDestStation, trainCars);
+					JobChainController emptyHaulJobChainController = EmptyHaulJobGenerator.GenerateEmptyHaulJobWithExistingCarsOrNull(station, viableDestStation, startingTrack, trainCars, _Random, possibleDestinationTrack);
+					if (emptyHaulJobChainController != null)
+					{
+						emptyHaulJobChainController.FinalizeSetupAndGenerateFirstJob();
+						jobChainControllers.Add(emptyHaulJobChainController);
+						return;
+					}
+				}
+				else
+				{
+					Main._modEntry.Logger.Error($"Empty consist of {trainCars.Count()} pax cars starting with {trainCars.First().ID} can´t be reassigned a LH to any pax station, attempting splitting");
+					jobChainControllers.AddRange(HandleSplitOrFail(trainCars, station));
+					return;
+				}
+			}
+
+			Main._modEntry.Logger.Error("[HandleEmptyPaxCars] End of function reached possibly without reassigning, this shouldn´t happen!");
+		}
+
+
+		#region PaxJobs Patches
 
 #pragma warning disable IDE0060 // Remove unused parameter
 
-        private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
-        {
-            List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
-            RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
-            if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
-            var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
+		private static bool GenerateJob_Prefix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, out bool __state)
+		{
+			__state = true;
+			var instanceBase = (StaticJobDefinition)__instance;
+			List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+			RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
+			if (_DestinationTracksField.GetValue(__instance) is not Array rrTracksArray || rrTracksArray.Length == 0) return false;
+			var destinationTracks = rrTracksArray.Cast<object>().Select(o => new RouteTrackRef(o)).ToList();
 
-            if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
-            {
-                Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
-                return false;
-            }
+			if ((cars == null) || (cars.Count == 0) || (startingRouteTrack.Value == null) || (destinationTracks == null))
+			{
+				Main._modEntry.Logger.Log("Failed to generate passengers job, bad data");
+				return false;
+			}
 
-            if (cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None))
-            {
-                return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: true);
-            }
+			bool loaded = cars.Any(c => c.CurrentCargoTypeInCar != CargoType.None);
+			if (string.IsNullOrEmpty(forcedJobId)) /*generating new job case*/
+			{
+				if (loaded)
+				{
+					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: true);
+				}
+				if (GetRouteTrackTrackField(startingRouteTrack) != CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars))) //cars not at platform
+				{
+					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: false, tracksMismatch: true);
+				}
 
-            if (GetRouteTrackTrackField(startingRouteTrack) != CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars)))
-            {
-                return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: false, tracksMismatch: true);
-            }
+				return true; //if cars are empty and on platform let PaxJobs generate job normally
+			}
+			else /*loading job from save data case*/
+			{
+				//var jobDefComponent = (MonoBehaviour)__instance;
+				//var currentJcc = jobDefComponent.GetComponent<JobChainController>();
+				//var chainsInStation = StationController.GetStationByYardID(jobOriginStation.ID).ProceduralJobsController.GetCurrentJobChains();
+				//var currentJcc = chainsInStation.FirstOrDefault(jcc => jcc.carsForJobChain.MultisetEquals(cars) && jcc.jobChain.Any(sjd => (string)CompatAccess.Field(sjd.GetType(), "forcedJobId").GetValue(sjd) == forcedJobId));
 
-            return true;
-        }
+				/*if (currentJcc == null)
+				{
+					Main._modEntry.Logger.Error($"JCC not found on GameObject for job {forcedJobId}");
+					//return true;
+				}*/
+				//bool modified = currentJcc.jobChainGO.GetComponent<PaxJobModifiedFlag>() != null;
+				
+				var definitionGO = ((MonoBehaviour)__instance).gameObject;
+				bool modified = definitionGO.GetComponent<PaxJobModifiedFlag>() != null;
+				bool taken = definitionGO.GetComponent<PaxJobJobTakenFlag>() != null;
 
-        private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses)
-        {
-            RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
-            List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
-            var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
+				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded is {(!modified ? "not " : "")}modified");
+				Main._modEntry.Logger.Log($"Job {forcedJobId} getting loaded was {(!taken ? "not " : "")}taken");
 
-            if (GetRouteTrackTrackField(startingRouteTrack).ID.FullDisplayID != carsTrack.ID.FullDisplayID)
-            {
-                var jobs = jobOriginStation.availableJobs;
-                jobs.Reverse();
+				if (modified)
+				{
+					__state = false;
+					return !GeneratePaxJobOverride(cars, startingRouteTrack, destinationTracks, __instance, jobOriginStation, timeLimit, initialWage, forcedJobId, requiredLicenses, loaded: loaded, fromSave: true, taken: taken);
+				}
+				return true;
+			}
+		}
 
-                foreach (var job in jobs)
-                {
-                    if (job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential) is not SequentialTasks sequential) continue;
+		private static void GenerateJob_Postfix(object __instance, Station jobOriginStation, float timeLimit, float initialWage, string forcedJobId, JobLicenses requiredLicenses, bool __state)
+		{
+			if (__state)
+			{
+				RouteTrackRef startingRouteTrack = new(_StartingTrackField.GetValue(__instance));
+				List<Car> cars = (List<Car>)_TrainCarsToTransportProp.GetValue(__instance);
+				var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars));
 
-                    if (sequential.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Transport) is not TransportTask transport) continue;
+				if (GetRouteTrackTrackField(startingRouteTrack).ID.FullDisplayID != carsTrack.ID.FullDisplayID)
+				{
+					var jobs = jobOriginStation.availableJobs;
+					jobs.Reverse();
 
-                    if ((bool)!transport.GetTaskData().cars.SequenceEqual(cars)) continue;
+					foreach (var job in jobs)
+					{
+						if (job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential) is not SequentialTasks sequential) continue;
 
-                    var startTrack = (Track)_TaskStartingTrackField.GetValue(transport);
-                    if (startTrack == null || startTrack.ID.FullDisplayID == carsTrack.ID.FullDisplayID) continue;
+						if (sequential.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Transport) is not TransportTask transport) continue;
 
-                    _TaskStartingTrackField.SetValue(transport, carsTrack);
-                    Main._modEntry.Logger.Log($"Changed start strack for job {job.ID}");
-                    break;
-                }
-            }
-        }
+						if ((bool)!transport.GetTaskData().cars.SequenceEqual(cars)) continue;
 
-        private static bool StartGenerationAsync_Prefix(object __instance)
-        {
-            StationController generatingStation = (StationController)_PaxJGeneratorStContField.GetValue(__instance);
-            if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(generatingStation) && !OverrideSpawnFlagForPaxJ)
-            {
-                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} has already spawned cars, skipping passanger jobs with new cars generation");
-                return false;
-            }
-            else
-            {
-                Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} is generating passanger jobs with cars");
-                OverrideSpawnFlagForPaxJ = false;
-                return true;
-            }
-        }
+						var startTrack = (Track)_TaskStartingTrackField.GetValue(transport);
+						if (startTrack == null || startTrack.ID.FullDisplayID == carsTrack.ID.FullDisplayID) continue;
 
-        private static bool ExtractPassengerJobData_Prefix(ref Job_data job)
-        {
-            //adding a dummy load task data if there is none in origin station
+						_TaskStartingTrackField.SetValue(transport, carsTrack);
+						Main._modEntry.Logger.Log($"Changed start strack for job {job.ID}");
+						break;
+					}
+				}
+			}
+		}
 
-            bool result = FilterJobDataForModPaxJob(ref job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit);
-            if (exit) return result;
+		private static void LoadPassengerChain_Postfix(object __result, object[] __args)
+		{
+			if (__result != null)
+			{
+				Main._modEntry.Logger.Log("Flagg adding postfix runs");
+				var jcc = (JobChainController)__result;
+				var chainSaveData = (JobChainSaveData)__args[0];
 
-            Task_data[] newNestedTasks = null;
-            bool loadingFound = false;
-            foreach (var taskData in taskSequence.nestedTasks)
-            {
-                if (taskData.instanceTaskType != TaskType.Warehouse) continue;
-                if (taskData.warehouseTaskType == WarehouseTaskType.Loading)
-                {
-                    loadingFound = true;
-                    continue;
-                }
-                if (taskData.warehouseTaskType == WarehouseTaskType.Unloading && !loadingFound)
-                {
-                    //var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(CarTrackAssignment.TrainCarsByGuid(taskData.cars.Select(c => c.ID)));
-                    var carsTrack = firstNestedTask.startTrackID;
-                    if (carsTrack == null) break;
+				if (chainSaveData.currentJobTaskData == null || chainSaveData.currentJobTaskData.Length == 0) return;
 
-                    var destTrack = GetRouteTrackTrackField(GetPlatforms(GetStationData(carsTrack.yardId)).First());
-                    var taskList = taskSequence.nestedTasks.ToList();
-                    taskList.Insert(1, new Task_data(TaskType.Warehouse, TaskType.Warehouse, TaskState.InProgress, 0, 0, taskData.cars, carsTrack, destTrack.ID, WarehouseTaskType.None, new List<CargoType>(), 0, false, false, Array.Empty<Task_data>()));
-                    newNestedTasks = taskList.ToArray();
-                    break;
-                }
-            }
+				if (chainSaveData.jobTaken)
+				{
+					Main._modEntry.Logger.Log($"Adding 'JobTaken' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
+					jcc.jobChainGO.AddComponent<PaxJobJobTakenFlag>();
+				}
+				
 
-            if (newNestedTasks?.Length > 1) taskSequence.nestedTasks = newNestedTasks;
-            job.tasksData[0] = taskSequence;
-            return true;
-        }
+				var headTask = chainSaveData.currentJobTaskData[0];
+				if (headTask.type != TaskType.Sequential) return;
 
-        private static bool CreateLoadTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
-        {
-            //skip creation of load page for our modified jobs (starting with transport) that are from loaded cars
+				if (headTask is ComplexTaskSaveData complexData && complexData.tasksData.Length > 0)
+				{
+					var firstChild = complexData.tasksData[0];
+					if (firstChild.type == TaskType.Transport)
+					{
+						Main._modEntry.Logger.Log($"Adding 'modified' flag component to {jcc.jobChainGO.name} at {jcc.jobChain.First().logicStation.ID}");
+						jcc.jobChainGO.AddComponent<PaxJobModifiedFlag>();
+					}
+				}
+			}
+		}
 
-            PassengerJobDataRef jobData = new(__args[0]);
-            object initialStopInfo = __args[1];
-            if (_InitialStopField.GetValue(jobData.Value) == initialStopInfo)
-            {
-                var baseJobData = ((TransportJobData)jobData.Value).job;
-                bool result = FilterJobDataForModPaxJob(ref baseJobData, out _, out Task_data firstNestedTask, out bool exit);
-                if (exit) return result;
+		private static bool StartGenerationAsync_Prefix(object __instance)
+		{
+			StationController generatingStation = (StationController)_PaxJGeneratorStContField.GetValue(__instance);
+			if (StationIdCarSpawningPersistence.Instance.GetHasStationSpawnedCarsFlag(generatingStation) && !OverrideSpawnFlagForPaxJ)
+			{
+				Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} has already spawned cars, skipping passanger jobs with new cars generation");
+				return false;
+			}
+			else
+			{
+				Main._modEntry.Logger.Log($"Station {generatingStation.logicStation.ID} is generating passanger jobs with cars");
+				OverrideSpawnFlagForPaxJ = false;
+				return true;
+			}
+		}
 
-                if (firstNestedTask.startTrackID == firstNestedTask.destinationTrackID)
-                {
-                    //from context we now know (hopefully?) that the cars were loaded 
-                    __result = null;
-                    return false;
-                }
-            }
-            return true;
-        }
+		private static bool ExtractPassengerJobData_Prefix(ref Job_data job)
+		{
+			//adding a dummy load task data if there is none in origin station
 
-        private static bool CreateCoupleTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
-        {
-            PassengerJobDataRef jobData = new(__args[0]);
-            var baseJobData = (TransportJobData)(jobData.Value);
-            var station = baseJobData.job.chainOriginStationInfo;
-            var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
-            __result = (TemplatePaperData)(CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) })).Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
-            return false;
-        }
+			bool result = FilterJobDataForModPaxJob(ref job, out Task_data taskSequence, out Task_data firstNestedTask, out bool exit);
+			if (exit) return result;
 
-        private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)
-        {
-            __result = __result.Where(t => t != null).ToList();
-        }
+			Task_data[] newNestedTasks = null;
+			bool loadingFound = false;
+			foreach (var taskData in taskSequence.nestedTasks)
+			{
+				if (taskData.instanceTaskType != TaskType.Warehouse) continue;
+				if (taskData.warehouseTaskType == WarehouseTaskType.Loading)
+				{
+					loadingFound = true;
+					continue;
+				}
+				if (taskData.warehouseTaskType == WarehouseTaskType.Unloading && !loadingFound)
+				{
+					//var carsTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(CarTrackAssignment.TrainCarsByGuid(taskData.cars.Select(c => c.ID)));
+					var carsTrack = firstNestedTask.startTrackID;
+					if (carsTrack == null) break;
+
+					var destTrack = GetRouteTrackTrackField(GetPlatforms(GetStationData(carsTrack.yardId)).First());
+					var taskList = taskSequence.nestedTasks.ToList();
+					taskList.Insert(1, new Task_data(TaskType.Warehouse, TaskType.Warehouse, TaskState.InProgress, 0, 0, taskData.cars, carsTrack, destTrack.ID, WarehouseTaskType.None, new List<CargoType>(), 0, false, false, Array.Empty<Task_data>()));
+					newNestedTasks = taskList.ToArray();
+					break;
+				}
+			}
+
+			if (newNestedTasks?.Length > 1) taskSequence.nestedTasks = newNestedTasks;
+			job.tasksData[0] = taskSequence;
+			return true;
+		}
+
+		private static bool CreateLoadTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+		{
+			//skip creation of load page for our modified jobs (starting with transport) that are from loaded cars
+
+			PassengerJobDataRef jobData = new(__args[0]);
+			object initialStopInfo = __args[1];
+			if (_InitialStopField.GetValue(jobData.Value) == initialStopInfo)
+			{
+				var baseJobData = ((TransportJobData)jobData.Value).job;
+				bool result = FilterJobDataForModPaxJob(ref baseJobData, out _, out Task_data firstNestedTask, out bool exit);
+				if (exit) return result;
+
+				if (firstNestedTask.startTrackID == firstNestedTask.destinationTrackID)
+				{
+					//from context we now know (hopefully?) that the cars were loaded 
+					__result = null;
+					return false;
+				}
+			}
+			return true;
+		}
+
+		private static bool CreateCoupleTaskPage_Prefix(ref TemplatePaperData __result, object[] __args)
+		{
+			PassengerJobDataRef jobData = new(__args[0]);
+			var baseJobData = (TransportJobData)(jobData.Value);
+			var station = baseJobData.job.chainOriginStationInfo;
+			var startingTrack = baseJobData.job.tasksData.FirstOrDefault(t => t.instanceTaskType == TaskType.Sequential)?.nestedTasks.FirstOrDefault(t => t.instanceTaskType == TaskType.Transport)?.startTrackID ?? baseJobData.startingTrack;
+			__result = (TemplatePaperData)(CompatAccess.Method(typeof(BookletCreator_Job), "CreateCoupleTaskPaperData", new[] { typeof(int), typeof(string), typeof(Color), typeof(string), typeof(List<Car_data>), typeof(List<CargoType>), typeof(int), typeof(int) })).Invoke(null, new object[] { (int)__args[1], station.YardID, station.StationColor, startingTrack.TrackPartOnly, baseJobData.transportingCars, baseJobData.transportedCargoPerCar, (int)__args[2], (int)__args[3] });
+			return false;
+		}
+
+		private static void GetBookletTemplateData_Postfix(Job_data job, ref List<TemplatePaperData> __result)
+		{
+			__result = __result.Where(t => t != null).ToList();
+		}
 
 #pragma warning restore IDE0060 // Remove unused parameter
-        #endregion
-    }
+		#endregion
+	}
 }

--- a/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
+++ b/PersistentJobsMod/ModInteraction/PaxJobsCompat.cs
@@ -163,7 +163,14 @@ namespace PersistentJobsMod.ModInteraction
 
         private static object GetStationData(string yardId) => _GetStationData?.Invoke(null, new object[] { yardId }); // output is IPassDestination : PassStationData
 
-        private static object GetRouteTrackById(string trackFullDisplayId) => _GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId });
+        private static object GetRouteTrackByIdOrNull(string trackFullDisplayId)
+        {
+            object routeTrackObj = _GetRouteTrackById?.Invoke(null, new object[] { trackFullDisplayId });
+            if (routeTrackObj is null) return null;
+            Track trackField = GetRouteTractTrackField(routeTrackObj);
+            if (trackField == null || trackField.RailTrack() == null || trackField.ID == null || trackField.ID.FullDisplayID == null) return null;
+            return routeTrackObj;
+        }
 
         private static List<Track> AllPaxTracksForStationData(string yardId) => ((IEnumerable<Track>)_AllTracksProperty.GetValue(GetStationData(yardId))).ToList();
 
@@ -175,7 +182,13 @@ namespace PersistentJobsMod.ModInteraction
             if (result is System.Collections.IEnumerable enumerable) foreach (var item in enumerable) yield return item;
         }
 
-        private static Track GetRouteTractTrackField(object routeTrack) => (Track)_RouteTrackTrackField.GetValue(routeTrack);
+        private static Track GetRouteTractTrackField(object routeTrack)
+        {
+            if (routeTrack == null) return null;
+            var track = (Track)_RouteTrackTrackField.GetValue(routeTrack);
+            if (track == null || track.RailTrack() == null || track.ID == null || track.ID.FullDisplayID == null) return null;
+            return track;
+        }
 
         private static object GetPaxHaulJobDefStartingRouteTrackField(StaticJobDefinition staticPaxJobDefinition) => _StartingTrackField.GetValue(staticPaxJobDefinition);
 
@@ -191,41 +204,49 @@ namespace PersistentJobsMod.ModInteraction
             return _PassengerExpress;
         }
 
+        private static object SelectStartPlatformRouteTrack(Track currentTrack, List<object> fittingPlatforms)
+        {
+            if (!fittingPlatforms.Any()) return null;
+
+            if (currentTrack != null)
+            {
+                string currentTrackId = currentTrack.ID.FullDisplayID;
+                var matchingPlatform = fittingPlatforms.FirstOrDefault(rt =>
+                {
+                    var track = GetRouteTractTrackField(rt);
+                    return track != null && track.ID.FullDisplayID == currentTrackId;
+                });
+
+                if (matchingPlatform != null)
+                {
+                    Main._modEntry.Logger.Log($"Using current platform track {currentTrackId} as PaxJobs start platform");
+                    return matchingPlatform;
+                }
+                Main._modEntry.Logger.Log($"Current track {currentTrackId} is not a PaxJobs platform, selecting random platform");
+            }
+            else Main._modEntry.Logger.Log("Could not determine current track, selecting random platform");
+
+            return RandomExtensions.GetRandomElement(_Random, fittingPlatforms);
+        }
+
         private static List<JobChainController> TryGeneratePassengerJob(StationController station, List<TrainCar> trainCars, List<object> fittingPlatforms, JobType jobType)
         {
             List<JobChainController> result = new();
-
             if (trainCars.Count() > 20) result.AddRange(HandleSplitOrFail(trainCars, station));
 
-            object preferredRouteTrack = null;
-            var currentTrackLogic = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
-            if (currentTrackLogic != null)
-            {
-                var currentRouteTrackObject = GetRouteTrackById(currentTrackLogic.ID.FullDisplayID);
-                if (currentRouteTrackObject != null)
-                {
-                    Main._modEntry.Logger.Log($"Current track for consist starting with {trainCars.First().ID} is {GetRouteTractTrackField(currentRouteTrackObject)}");
-
-                    string currentTrackId = GetRouteTractTrackField(currentRouteTrackObject).ID.FullDisplayID;
-                    if (fittingPlatforms.Any(rt => GetRouteTractTrackField(rt).ID.FullDisplayID == currentTrackId)) preferredRouteTrack = currentRouteTrackObject;
-                }
-                else Main._modEntry.Logger.Log($"Didn´t find PaxJobs RouteTrack for current track {currentTrackLogic.ID.FullID}");
-            }
-            else Main._modEntry.Logger.Log($"Couldn´t get current track for consist starting with {trainCars.First().ID}");
-
-            preferredRouteTrack ??= RandomExtensions.GetRandomElement(_Random, fittingPlatforms);
+            Track currentTrack = CarTrackAssignment.FindNearestNamedTrackOrNull(trainCars);
+            object preferredRouteTrack = SelectStartPlatformRouteTrack(currentTrack, fittingPlatforms);
             if (preferredRouteTrack == null)
             {
-                Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID} to generate a job.");
+                Main._modEntry.Logger.Log($"No fitting platforms found for consist starting with {trainCars.First().ID}");
                 result.AddRange(HandleSplitOrFail(trainCars, station));
                 return result;
             }
 
-            var consistInfo = CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars));
-
-            if (TryGenerateJob(station.stationInfo.YardID, jobType, consistInfo, out JobChainController passangerChainController))
+            if (TryGenerateJob(station.stationInfo.YardID, jobType, CreatePassConsistInfo(preferredRouteTrack, TrainCar.ExtractLogicCars(trainCars)), out JobChainController passangerChainController))
             {
                 Main._modEntry.Logger.Log($"Successfully reassigned pax consist starting with {trainCars.First().ID} to job {passangerChainController.currentJobInChain.ID}");
+                if (GetRouteTractTrackField(preferredRouteTrack).ID.FullDisplayID != currentTrack.ID.FullDisplayID) AddTransportTaskToTop(passangerChainController, currentTrack, GetRouteTractTrackField(preferredRouteTrack));
                 result.Add(passangerChainController);
                 return result;
             }
@@ -284,7 +305,7 @@ namespace PersistentJobsMod.ModInteraction
             return (emptyConsecutiveTrainCarGroups, loadedConsecutiveTrainCarGroups);
         }
 
-        private static void AddTransportTaskToTop(JobChainController paxJobChainController)
+        private static void AddTransportTaskToTop(JobChainController paxJobChainController, Track currentTrack, Track destinatiionTrack)
         {
             if (_PassengerChainController.IsInstanceOfType(paxJobChainController))
             {
@@ -297,7 +318,7 @@ namespace PersistentJobsMod.ModInteraction
                     var headSequentialTask = (SequentialTasks)job.tasks.FirstOrDefault(t => t.InstanceTaskType == TaskType.Sequential);
                     if (headSequentialTask != null)
                     {
-                        var newTransportTask = JobsGenerator.CreateTransportTask(cars, GetRouteTractTrackField(GetPaxHaulJobDefStartingRouteTrackField(staticPaxJobDefinition)), CarTrackAssignment.FindNearestNamedTrackOrNull(TrainCar.ExtractTrainCars(cars)));
+                        var newTransportTask = JobsGenerator.CreateTransportTask(cars, destinatiionTrack, currentTrack);
                         var newParallelHoldingTask = new ParallelTasks(new List<Task> { newTransportTask });
                         newParallelHoldingTask.SetJobBelonging(job);
                         headSequentialTask.tasks.AddFirst(newParallelHoldingTask);
@@ -460,14 +481,7 @@ namespace PersistentJobsMod.ModInteraction
 
                 JobType jobType = PickPassengerJobType(trainCars.Count);
                 if (station.stationInfo.YardID == "CS" && jobType == _PassengerExpress) jobType = _PassengerLocal; //we have to do this since City South doesn´t have any valid outgoing express routes 
-
-                List<JobChainController> processedControllers = new();
-                foreach (var jcc in TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType))
-                {
-                    AddTransportTaskToTop(jcc);
-                    processedControllers.Add(jcc);
-                }
-                jobChainControllers.AddRange(processedControllers);
+                jobChainControllers.AddRange(TryGeneratePassengerJob(station, trainCars, fittingPlatforms, jobType));
                 return;
             }
             else

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -104,6 +104,7 @@
     <Compile Include="HarmonyPatches\Console\Console_Patches.cs" />
     <Compile Include="HarmonyPatches\Sleeping\BedSleepingController_Patches.cs" />
     <Compile Include="HarmonyPatches\Trashcan\JobAbandoner_Patches.cs" />
+    <Compile Include="ModInteraction\PaxJobsCompat.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Utilities\AdditionalInformationException.cs" />
     <Compile Include="Utilities\AddMoreInfoToExceptionHelper.cs" />

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Extensions\TrackExtension.cs" />
     <Compile Include="Utilities\PaymentAndBonusTimeUtilities.cs" />
     <Compile Include="Utilities\PlayerSpawnedCarUtilities.cs" />
+    <Compile Include="Utilities\ReflectionUtilities.cs" />
     <Compile Include="Utilities\TaskUtilities.cs" />
     <Compile Include="Utilities\TranspilingUtilities.cs" />
     <Compile Include="HarmonyPatches\JobChainControllers\JobChainController_OnLastJobInChainCompleted_Patch.cs" />
@@ -149,22 +150,15 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-
-<Target Name="PostBuildCopyWithBackup" AfterTargets="Build">
-  <PropertyGroup>
-    <DeployDir>$(DvInstallDir)\Mods\PersistentJobsMod\</DeployDir>
-    <DeployFile>$(DeployDir)$(TargetFileName)</DeployFile>
-    <BackupFile>$(DeployFile).OLD</BackupFile>
-  </PropertyGroup>
-  <Move
-    SourceFiles="$(DeployFile)"
-    DestinationFiles="$(BackupFile)"
-    Condition="Exists('$(DeployFile)')" />
-  <Copy
-    SourceFiles="$(TargetPath)"
-    DestinationFiles="$(DeployFile)" />
-</Target>
-
+  <Target Name="PostBuildCopyWithBackup" AfterTargets="Build">
+    <PropertyGroup>
+      <DeployDir>$(DvInstallDir)\Mods\PersistentJobsMod\</DeployDir>
+      <DeployFile>$(DeployDir)$(TargetFileName)</DeployFile>
+      <BackupFile>$(DeployFile).OLD</BackupFile>
+    </PropertyGroup>
+    <Move SourceFiles="$(DeployFile)" DestinationFiles="$(BackupFile)" Condition="Exists('$(DeployFile)')" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(DeployFile)" />
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -149,10 +149,22 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+<Target Name="PostBuildCopyWithBackup" AfterTargets="Build">
   <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <DeployDir>$(DvInstallDir)\Mods\PersistentJobsMod\</DeployDir>
+    <DeployFile>$(DeployDir)$(TargetFileName)</DeployFile>
+    <BackupFile>$(DeployFile).OLD</BackupFile>
   </PropertyGroup>
+  <Move
+    SourceFiles="$(DeployFile)"
+    DestinationFiles="$(BackupFile)"
+    Condition="Exists('$(DeployFile)')" />
+  <Copy
+    SourceFiles="$(TargetPath)"
+    DestinationFiles="$(DeployFile)" />
+</Target>
+
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -46,6 +46,9 @@
     <Reference Include="CommandTerminal">
       <Private>False</Private>
     </Reference>
+    <Reference Include="DV.Common">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="DV.PointSet">
       <Private>False</Private>
     </Reference>
@@ -61,6 +64,9 @@
     <Reference Include="DV.UIFramework">
       <Private>False</Private>
     </Reference>
+    <Reference Include="DV.UserManagement">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="MessageBox">
       <Private>False</Private>
     </Reference>
@@ -73,6 +79,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.IO.Compression.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
       <Private>False</Private>
@@ -102,7 +109,8 @@
     <Compile Include="Console.cs" />
     <Compile Include="CarSpawningJobGenerators\EmptyHaulJobWithCarsGenerator.cs" />
     <Compile Include="HarmonyPatches\Console\Console_Patches.cs" />
-    <Compile Include="HarmonyPatches\Save\SaveGameManager_RemoveData_Patch.cs" />
+    <Compile Include="HarmonyPatches\Save\SaveGameData_RemoveData_Patch.cs" />
+    <Compile Include="HarmonyPatches\Save\StartGameData_FromSaveGame_Patch.cs" />
     <Compile Include="HarmonyPatches\Sleeping\BedSleepingController_Patches.cs" />
     <Compile Include="HarmonyPatches\Trashcan\JobAbandoner_Patches.cs" />
     <Compile Include="ModInteraction\PaxJobsCompat.cs" />
@@ -158,20 +166,12 @@
       <DeployPdb>$(DeployDir)$(TargetName).pdb</DeployPdb>
       <BackupDll>$(DeployDll).OLD</BackupDll>
     </PropertyGroup>
-  
     <!-- Backup existing DLL -->
-    <Move SourceFiles="$(DeployDll)"
-          DestinationFiles="$(BackupDll)"
-          Condition="Exists('$(DeployDll)')" />
-  
+    <Move SourceFiles="$(DeployDll)" DestinationFiles="$(BackupDll)" Condition="Exists('$(DeployDll)')" />
     <!-- Copy DLL -->
-    <Copy SourceFiles="$(TargetPath)"
-          DestinationFiles="$(DeployDll)" />
-  
+    <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(DeployDll)" />
     <!-- Copy PDB if present -->
-    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb"
-          DestinationFiles="$(DeployPdb)"
-          Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(DeployPdb)" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -154,11 +154,24 @@
   <Target Name="PostBuildCopyWithBackup" AfterTargets="Build">
     <PropertyGroup>
       <DeployDir>$(DvInstallDir)\Mods\PersistentJobsMod\</DeployDir>
-      <DeployFile>$(DeployDir)$(TargetFileName)</DeployFile>
-      <BackupFile>$(DeployFile).OLD</BackupFile>
+      <DeployDll>$(DeployDir)$(TargetFileName)</DeployDll>
+      <DeployPdb>$(DeployDir)$(TargetName).pdb</DeployPdb>
+      <BackupDll>$(DeployDll).OLD</BackupDll>
     </PropertyGroup>
-    <Move SourceFiles="$(DeployFile)" DestinationFiles="$(BackupFile)" Condition="Exists('$(DeployFile)')" />
-    <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(DeployFile)" />
+  
+    <!-- Backup existing DLL -->
+    <Move SourceFiles="$(DeployDll)"
+          DestinationFiles="$(BackupDll)"
+          Condition="Exists('$(DeployDll)')" />
+  
+    <!-- Copy DLL -->
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFiles="$(DeployDll)" />
+  
+    <!-- Copy PDB if present -->
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb"
+          DestinationFiles="$(DeployPdb)"
+          Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
   </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/PersistentJobsMod/PersistentJobsMod.csproj
+++ b/PersistentJobsMod/PersistentJobsMod.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Console.cs" />
     <Compile Include="CarSpawningJobGenerators\EmptyHaulJobWithCarsGenerator.cs" />
     <Compile Include="HarmonyPatches\Console\Console_Patches.cs" />
+    <Compile Include="HarmonyPatches\Save\SaveGameManager_RemoveData_Patch.cs" />
     <Compile Include="HarmonyPatches\Sleeping\BedSleepingController_Patches.cs" />
     <Compile Include="HarmonyPatches\Trashcan\JobAbandoner_Patches.cs" />
     <Compile Include="ModInteraction\PaxJobsCompat.cs" />
@@ -136,7 +137,7 @@
     <Compile Include="Persistence\StationIdCarSpawningPersistence.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HarmonyPatches\Save\SaveDataConstants.cs" />
-    <Compile Include="HarmonyPatches\Save\CarsSaveManager_Load_Patch.cs" />
+    <Compile Include="HarmonyPatches\Save\CarsSaveManager_Patches.cs" />
     <Compile Include="HarmonyPatches\Save\SaveGameManager_Save_Patch.cs" />
     <Compile Include="JobGenerators\ShuntingLoadJobGenerator.cs" />
     <Compile Include="HarmonyPatches\Distance\StationController_Patches.cs" />

--- a/PersistentJobsMod/Properties/AssemblyInfo.cs
+++ b/PersistentJobsMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("3.5.0.1")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PersistentJobsMod/Settings.cs
+++ b/PersistentJobsMod/Settings.cs
@@ -7,6 +7,9 @@ namespace PersistentJobsMod {
 
         public bool PreventStartingShuntingJobForCarsOnWarehouseTrackMessageWasShown = false;
 
+        [Draw("Show track signs for all named tracks")]
+        public bool GenerateTrackSigns = true;
+
         public override void Save(UnityModManager.ModEntry modEntry) {
             Save(this, modEntry);
         }

--- a/PersistentJobsMod/Utilities/AddMoreInfoToExceptionHelper.cs
+++ b/PersistentJobsMod/Utilities/AddMoreInfoToExceptionHelper.cs
@@ -1,5 +1,14 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
+using MessageBox;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using UnityEngine;
+using DV.Common;
+using DV.UserManagement;
+using DV.Utils;
+using DV.UserManagement.Data;
 
 namespace PersistentJobsMod.Utilities {
     public static class AddMoreInfoToExceptionHelper {
@@ -34,6 +43,58 @@ namespace PersistentJobsMod.Utilities {
                     throw;
                 }
                 throw new AdditionalInformationException(additionalInformation, exception);
+            }
+        }
+
+        public static void AlertPlayerToExceptionAndCompileDataForBugReport(Exception e, string location)
+        {
+            try
+            {
+                var logMessage = $"Exception thrown at {location}:\n{e}";
+                Debug.LogError(logMessage);
+
+                var dataDir = Application.persistentDataPath;
+
+                var exceptionFileName = $"PersistentJobsMod_Exception_{DateTime.Now.ToString("O").Replace(':', '.')}";
+                var exceptionOutFolder = Path.Combine(dataDir, exceptionFileName);
+                Directory.CreateDirectory(exceptionOutFolder);
+                File.WriteAllText(Path.Combine(exceptionOutFolder, Path.ChangeExtension(exceptionFileName, ".log")), logMessage);
+
+                var currentSession = SingletonBehaviour<UserManager>.Instance.CurrentUser.CurrentSession as GameSession;
+                string savesDir = Path.Combine(dataDir, Path.Combine(currentSession.BasePath, "Saves"));
+                
+                var dirInfo = new DirectoryInfo(savesDir);
+                var lastSaveFile = (from f in dirInfo.GetFiles("*.save") orderby f.LastWriteTime descending select f).FirstOrDefault();
+                var lastJsonFile = (from f in dirInfo.GetFiles("*.json") orderby f.LastWriteTime descending select f).FirstOrDefault();
+
+                lastSaveFile?.CopyTo(Path.Combine(exceptionOutFolder, "beforeEx_" + lastSaveFile.Name));
+                lastJsonFile?.CopyTo(Path.Combine(exceptionOutFolder, "beforeEx_" + lastJsonFile.Name));
+
+                currentSession.Save();
+                var sessionFPath = Path.Combine(currentSession.BasePath, "sessionData.json");
+                if (File.Exists(sessionFPath)) File.Copy(sessionFPath, Path.Combine(exceptionOutFolder, "sessionData.json"));
+
+                SingletonBehaviour<SaveGameManager>.Instance.Save(SaveType.Auto, null, true);
+                var newSaveFile = (from f in dirInfo.GetFiles("*.save") orderby f.LastWriteTime descending select f).FirstOrDefault();
+                var newJsonFile = (from f in dirInfo.GetFiles("*.json") orderby f.LastWriteTime descending select f).FirstOrDefault();
+
+                newSaveFile?.CopyTo(Path.Combine(exceptionOutFolder, "afterEx_" + newSaveFile.Name));
+                newJsonFile?.CopyTo(Path.Combine(exceptionOutFolder, "afterEx_" + newJsonFile.Name));
+
+                var logFPath = Path.Combine(dataDir, "Player.log");
+                if (File.Exists(logFPath)) File.Copy(logFPath, Path.Combine(exceptionOutFolder, "Player.log"), overwrite: true);
+
+                string readmeStr = ($"If you see this, please go make a bug report concerning this. \nThe preferred way is at \"https://github.com/Banjobeni/DerailValley-PersistentJobs/issues\". You should describe what you were doing in game at the moment the exception fired. \nDon´t forget to add this .zip file, it contains the logs and relevant saves! \n\n If you don´t know/want to interact with GitHub, you can mention this issue in the \"#mods-support-and-bugs\" chanel on the \"Altfuture\" discord server tagging \"@8029\" or \"@Banjobeni\" with the same info, whilst also including this file. \nThank you for this help in the developement of this mod. ");
+                File.WriteAllText(Path.Combine(exceptionOutFolder, "ReadME.txt"), readmeStr);
+
+                ZipFile.CreateFromDirectory(exceptionOutFolder, Path.ChangeExtension(exceptionOutFolder, ".zip"));
+                Directory.Delete(exceptionOutFolder, true);
+
+                PopupAPI.ShowOk($"Persistent Jobs mod encountered a critical failure. The mod will stay inactive until the game is restarted.\n\nSee {exceptionFileName} for details.", onClose: c => { PopupAPI.ShowOk($"The game should be restarted now, not doing so is going to result in problems (eg. cars and jobs disappearing). It might be beneficial to load an earlier save. \nIt would be appreciated if you reported this issue on the mod´s GitHub or the Altfuture discord server. A zipped folder containing the required info has been created at {exceptionOutFolder}"); });
+            }
+            catch (Exception ex)
+            {
+                Main._modEntry.Logger.LogException("Failed to generate bug report: ", ex);
             }
         }
     }

--- a/PersistentJobsMod/Utilities/CarTrackAssignment.cs
+++ b/PersistentJobsMod/Utilities/CarTrackAssignment.cs
@@ -1,11 +1,25 @@
+using DV.Logic.Job;
+using DV.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using DV.Logic.Job;
 using UnityEngine;
 
 namespace PersistentJobsMod.Utilities {
     public static class CarTrackAssignment {
+
+        public static List<TrainCar> TrainCarsByGuid(IEnumerable<string> carGuid)
+        {
+            List<TrainCar> trainCars = new();
+
+            foreach (var car in carGuid)
+            {
+                trainCars.Add(SingletonBehaviour<TrainCarRegistry>.Instance.GetTrainCarByCarGuid(car) ?? throw new NullReferenceException($"Car GUID {car} does not correspond to any existing car"));
+            }
+
+            return trainCars;
+        }
+
         public static Track FindNearestNamedTrackOrNull(IReadOnlyList<TrainCar> trainCars) {
             var medianCarCount = trainCars.Count / 2;
 

--- a/PersistentJobsMod/Utilities/PlayerSpawnedCarUtilities.cs
+++ b/PersistentJobsMod/Utilities/PlayerSpawnedCarUtilities.cs
@@ -5,7 +5,7 @@ using HarmonyLib;
 namespace PersistentJobsMod.Utilities {
     public static class PlayerSpawnedCarUtilities {
         public static void ConvertPlayerSpawnedTrainCar(TrainCar trainCar) {
-            if (!trainCar.playerSpawnedCar) {
+            if (!trainCar.playerSpawnedCar || trainCar == null) {
                 return;
             }
 

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -1,0 +1,27 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace PersistentJobsMod.Utilities
+{
+    public static class ReflectionUtilities
+    {
+        public class CompatAccess
+        {
+            public static Type Type(string fullName) => AccessTools.TypeByName(fullName) ?? throw new TypeLoadException($"Type not found: {fullName}");
+            public static MethodInfo Method(Type type, string name, Type[] args = null) => (args == null ? AccessTools.Method(type, name) : AccessTools.Method(type, name, args)) ?? throw new MissingMethodException(type.FullName, name);
+            public static ConstructorInfo Ctor(Type type, Type[] args) => AccessTools.Constructor(type, args) ?? throw new MissingMethodException(type.FullName, ".ctor");
+            public static PropertyInfo Property(Type type, string name) => AccessTools.Property(type, name) ?? throw new MissingMemberException(type.FullName, name);
+            public static FieldInfo Field(Type type, string name) => AccessTools.Field(type, name) ?? throw new MissingFieldException(type.FullName, name);
+            public static Type IEnumerableOf(Type elementType) => typeof(IEnumerable<>).MakeGenericType(elementType);
+        }
+
+        public readonly struct Foreign<TTag>
+        {
+            public readonly object Value;
+            public Foreign(object value) => Value = value /*?? throw new ArgumentNullException(nameof(value))*/;
+            public override string ToString() => $"{typeof(TTag).Name}";
+        }
+    }
+}

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -24,9 +24,13 @@ namespace PersistentJobsMod.Utilities
             public override string ToString() => $"{typeof(TTag).Name}";
         }
 
+        public static List<(MethodInfo target, Type patchContainer, string patchMethodName)> patchRecord = new();
+
         public static void PatchPrefix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, prefix: hm), (target.DeclaringType.Name + "." + target.Name));
 
         public static void PatchPostfix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, postfix: hm), (target.DeclaringType.Name + "." + target.Name));
+
+        public static void PatchReverse(MethodInfo target, Type patchContainer, string patchMethodName) => PatchReverseMethod(target, patchContainer, patchMethodName, target.DeclaringType.Name + "." + target.Name);
 
         private static void PatchMethod(MethodInfo target, Type patchContainer, string patchMethodName, Action<Harmony, MethodInfo, HarmonyMethod> applyPatch, string logName)
         {
@@ -46,7 +50,32 @@ namespace PersistentJobsMod.Utilities
 
             applyPatch(Main.Harmony, target, new HarmonyMethod(patchMethod));
 
+            patchRecord.Add((target, patchContainer, patchMethodName));
+            
             Main._modEntry.Logger.Log($"Successfully patched {logName}");
+        }
+
+        private static void PatchReverseMethod(MethodInfo target, Type patchContainer, string patchMethodName, string logName)
+        {
+            if (target == null)
+            {
+                Main._modEntry.Logger.Error($"Target method not found for {logName}");
+                throw new MethodAccessException();
+            }
+
+            var patchMethod = patchContainer.GetMethod(patchMethodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+            if (patchMethod == null)
+            {
+                Main._modEntry.Logger.Error($"Reverse patch method '{patchMethodName}' not found for {logName}");
+                throw new MethodAccessException();
+            }
+
+            Main.Harmony.CreateReversePatcher(target, new HarmonyMethod(patchMethod)).Patch();
+
+            patchRecord.Add((target, patchContainer, patchMethodName));
+
+            Main._modEntry.Logger.Log($"Successfully reverse patched {logName}");
         }
     }
 }

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -23,5 +23,30 @@ namespace PersistentJobsMod.Utilities
             public Foreign(object value) => Value = value /*?? throw new ArgumentNullException(nameof(value))*/;
             public override string ToString() => $"{typeof(TTag).Name}";
         }
+
+        public static void PatchPrefix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, prefix: hm), (target.DeclaringType.Name + "." + target.Name));
+
+        public static void PatchPostfix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, postfix: hm), (target.DeclaringType.Name + "." + target.Name));
+
+        private static void PatchMethod(MethodInfo target, Type patchContainer, string patchMethodName, Action<Harmony, MethodInfo, HarmonyMethod> applyPatch, string logName)
+        {
+            if (target == null)
+            {
+                Main._modEntry.Logger.Error($"Target method not found for {logName}");
+                throw new MethodAccessException();
+            }
+
+            var patchMethod = patchContainer.GetMethod(patchMethodName, BindingFlags.Static | BindingFlags.NonPublic);
+
+            if (patchMethod == null)
+            {
+                Main._modEntry.Logger.Error($"Patch method '{patchMethodName}' not found for {logName}");
+                throw new MethodAccessException();
+            }
+
+            applyPatch(Main.Harmony, target, new HarmonyMethod(patchMethod));
+
+            Main._modEntry.Logger.Log($"Successfully patched {logName}");
+        }
     }
 }

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -36,7 +36,7 @@ namespace PersistentJobsMod.Utilities
                 throw new MethodAccessException();
             }
 
-            var patchMethod = patchContainer.GetMethod(patchMethodName, BindingFlags.Static | BindingFlags.NonPublic);
+            var patchMethod = patchContainer.GetMethod(patchMethodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
             if (patchMethod == null)
             {

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 
 namespace PersistentJobsMod.Utilities
 {
@@ -76,6 +77,24 @@ namespace PersistentJobsMod.Utilities
             patchRecord.Add((target, patchContainer, patchMethodName));
 
             Main._modEntry.Logger.Log($"Successfully reverse patched {logName}");
+        }
+        
+        public static void UnpatchAll()
+        {
+            StringBuilder s = new();
+            foreach (var (target, patchContainer, patchMethodName) in ReflectionUtilities.patchRecord)
+            {
+                try
+                {
+                    Main.Harmony.Unpatch(target, HarmonyPatchType.All, Main.Harmony.Id);
+                }
+                catch (Exception ex)
+                {
+                    Main._modEntry.Logger.LogException($"Error when unpatching {target.Name}!", ex);
+                    s.AppendLine(target.Name + ": " + ex.Message);
+                }
+            }
+            if (s.Length > 0) HarmonyPatches.Save.WorldStreaminInit_Patch.ShowPopupOnPlayerSpawn("State is not clean, there might be problems. \n" + s);
         }
     }
 }

--- a/PersistentJobsMod/Utilities/ReflectionUtilities.cs
+++ b/PersistentJobsMod/Utilities/ReflectionUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
@@ -25,13 +26,39 @@ namespace PersistentJobsMod.Utilities
             public override string ToString() => $"{typeof(TTag).Name}";
         }
 
+        public static bool IsInCallers(string methodName, string excludeMethodName = "", string specificFrameNumeric = "", int framesToSkip = 0, bool log = false)
+        {
+            bool specific = int.TryParse(specificFrameNumeric, out int intSpecificFrame);
+            StackTrace trace = new(framesToSkip, log);
+            StringBuilder callerNames = new();
+            if (specific)
+            {
+                var method = trace.GetFrame(intSpecificFrame).GetMethod();
+                callerNames.Append($"{method.DeclaringType?.Namespace}.{method.DeclaringType?.Name}.{method.Name}");
+                if (log) Main._modEntry.Logger.Log($"frame {intSpecificFrame} is {methodName}");
+            }
+            else
+            {
+                if (log) Main._modEntry.Logger.Log("getting all frames");
+                foreach (StackFrame frame in trace.GetFrames())
+                {
+                    var method = frame.GetMethod();
+                    callerNames.Append($"{method.DeclaringType?.Namespace}.{method.DeclaringType?.Name}.{method.Name} \n");
+                }
+            }
+            if (log) Main._modEntry.Logger.Log(callerNames.ToString());
+            if (excludeMethodName.Length > 1 && ((callerNames.ToString()).Contains(excludeMethodName))) return false;
+            if ((callerNames.ToString()).Contains(methodName)) return true;
+            return false;
+        }
+
         public static List<(MethodInfo target, Type patchContainer, string patchMethodName)> patchRecord = new();
 
-        public static void PatchPrefix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, prefix: hm), (target.DeclaringType.Name + "." + target.Name));
+        public static void PatchPrefix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, prefix: hm), (target.DeclaringType.Namespace + "." + target.DeclaringType.Name + "." + target.Name));
 
-        public static void PatchPostfix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, postfix: hm), (target.DeclaringType.Name + "." + target.Name));
+        public static void PatchPostfix(MethodInfo target, Type patchContainer, string patchMethodName) => PatchMethod(target, patchContainer, patchMethodName, (harmony, t, hm) => harmony.Patch(t, postfix: hm), (target.DeclaringType.Namespace + "." + target.DeclaringType.Name + "." + target.Name));
 
-        public static void PatchReverse(MethodInfo target, Type patchContainer, string patchMethodName) => PatchReverseMethod(target, patchContainer, patchMethodName, target.DeclaringType.Name + "." + target.Name);
+        public static void PatchReverse(MethodInfo target, Type patchContainer, string patchMethodName) => PatchReverseMethod(target, patchContainer, patchMethodName, target.DeclaringType.Namespace + "." + target.DeclaringType.Name + "." + target.Name);
 
         private static void PatchMethod(MethodInfo target, Type patchContainer, string patchMethodName, Action<Harmony, MethodInfo, HarmonyMethod> applyPatch, string logName)
         {
@@ -52,7 +79,7 @@ namespace PersistentJobsMod.Utilities
             applyPatch(Main.Harmony, target, new HarmonyMethod(patchMethod));
 
             patchRecord.Add((target, patchContainer, patchMethodName));
-            
+
             Main._modEntry.Logger.Log($"Successfully patched {logName}");
         }
 
@@ -78,7 +105,7 @@ namespace PersistentJobsMod.Utilities
 
             Main._modEntry.Logger.Log($"Successfully reverse patched {logName}");
         }
-        
+
         public static void UnpatchAll()
         {
             StringBuilder s = new();


### PR DESCRIPTION
Adds an optional compatibility layer that can handle passenger cars and jobs, does so heavily using reflection, thus not introducing even a compile-time dependency.
~~Dependant of a few small changes in PaxJobs: see [PR](https://github.com/katycat5e/DVPassengerJobs/pull/75).~~ 

~~Prebuilt files for testing:~~
~~[PersJ](https://github.com/user-attachments/files/24917733/PersistentJobsMod.zip)~~
~~[PassengerJobs](https://github.com/user-attachments/files/24917766/PassengerJobs.zip)~~



Now updated for PaxJobs v5.2.2 - changes there no longer needed!

Prebuilt files for testing:
[PersistentJobsMod.zip](https://github.com/user-attachments/files/26450161/PersistentJobsMod.zip)